### PR TITLE
Changes in overview, getting started and array data types

### DIFF
--- a/docs/backend-api/how-to/.pages.yml
+++ b/docs/backend-api/how-to/.pages.yml
@@ -7,3 +7,4 @@ nav:
     - how-to-obtain-information-from-report.md
     - how-to-create-a-rule.md
     - how-to-work-with-notifications.md
+    -

--- a/docs/backend-api/how-to/.pages.yml
+++ b/docs/backend-api/how-to/.pages.yml
@@ -6,4 +6,3 @@ nav:
     - get-track-points.md
     - how-to-obtain-information-from-report.md
     - how-to-create-a-rule.md
-    - how-to-work-with-notifications.md

--- a/docs/backend-api/how-to/.pages.yml
+++ b/docs/backend-api/how-to/.pages.yml
@@ -7,4 +7,3 @@ nav:
     - how-to-obtain-information-from-report.md
     - how-to-create-a-rule.md
     - how-to-work-with-notifications.md
-    -

--- a/docs/backend-api/how-to/.pages.yml
+++ b/docs/backend-api/how-to/.pages.yml
@@ -6,3 +6,4 @@ nav:
     - get-track-points.md
     - how-to-obtain-information-from-report.md
     - how-to-create-a-rule.md
+    - how-to-work-with-notifications.md

--- a/docs/backend-api/how-to/get-track-points.md
+++ b/docs/backend-api/how-to/get-track-points.md
@@ -31,7 +31,7 @@ Optional parameters:
   this number of points. Min=2, Max=3000.
 * `filter` – boolean. If `true`, the returned track will be filtered, applicable only for LBS tracks. It is `false` 
 by default.
-* `split` – boolean. Default=`true`. If `false`, all tracks will be merged into single one, and response will contain parking points.
+* `split` – boolean. Default=`true`. If `false`, all tracks will be merged into single one.
 
 The platform will reply:
 

--- a/docs/backend-api/how-to/get-track-points.md
+++ b/docs/backend-api/how-to/get-track-points.md
@@ -62,7 +62,7 @@ The platform will reply:
 * `lng` - float.  Longitude.
 * `alt` - int. Altitude in meters. 
 * `satellites` - int. Number of satellites used in fix for this point.
-* `get_time` - string date/time. GPS timestamp of the point, in user's timezone.
+* `get_time` - date/time. GPS timestamp of the point, in user's timezone.
 * `address` - string. Point address. Will be "" if no address recorded.
 * `heading` - int. Bearing in degrees (0..360).
 * `speed` - int. Speed in km/h.
@@ -80,7 +80,8 @@ curl -X POST '{{ extra.api_example_url }}/track/download' \
     -d '{"hash": "22eac1c27af4be7b9d04da2ce1af111b", "tracker_id": "123456", "from": "2020-09-23 03:24:00", "to": "2020-09-23 06:24:00", "format": "kml", "split": "false"}'
 ```
 
-All parameters are identical with track/read with the except of one new optional parameters:
+
+All parameters are the same with track/read plus two new optional parameters:
 
 * `format` – string. File format, "kml" or "kmz". Default is "kml".
 * `split` – boolean. If `true`, split tracks by folders with start/end placemarks and track line. Default `false`.

--- a/docs/backend-api/how-to/get-track-points.md
+++ b/docs/backend-api/how-to/get-track-points.md
@@ -31,7 +31,6 @@ Optional parameters:
   this number of points. Min=2, Max=3000.
 * `filter` – boolean. If `true`, the returned track will be filtered, applicable only for LBS tracks. It is `false` 
 by default.
-* `split` – boolean. Default=`true`. If `false`, all tracks will be merged into single one.
 
 The platform will reply:
 
@@ -62,13 +61,14 @@ The platform will reply:
 * `lng` - float.  Longitude.
 * `alt` - int. Altitude in meters. 
 * `satellites` - int. Number of satellites used in fix for this point.
-* `get_time` - date/time. GPS timestamp of the point, in user's timezone.
+* `get_time` - string date/time. GPS timestamp of the point, in user's timezone.
 * `address` - string. Point address. Will be "" if no address recorded.
 * `heading` - int. Bearing in degrees (0..360).
 * `speed` - int. Speed in km/h.
 * `precision` - optional int. Precision in meters.
 * `gsm_lbs` - optional boolean. `true` if location detected by GSM LBS.
 * `parking` - optional boolean. `true` if point does not belong to track.
+* `split` – boolean. If `true`, split tracks by folders with start/end placemarks and track line. Default `false`.
 
 You can also [download](../resources/tracking/track/index.md#download) a KML file. 
 You could use this file with map services. 
@@ -80,8 +80,6 @@ curl -X POST '{{ extra.api_example_url }}/track/download' \
     -d '{"hash": "22eac1c27af4be7b9d04da2ce1af111b", "tracker_id": "123456", "from": "2020-09-23 03:24:00", "to": "2020-09-23 06:24:00", "format": "kml", "split": "false"}'
 ```
 
-
-All parameters are the same with track/read plus two new optional parameters:
+All parameters are identical with track/read with the except of one new optional parameters:
 
 * `format` – string. File format, "kml" or "kmz". Default is "kml".
-* `split` – boolean. If `true`, split tracks by folders with start/end placemarks and track line. Default `false`.

--- a/docs/backend-api/how-to/get-track-points.md
+++ b/docs/backend-api/how-to/get-track-points.md
@@ -31,6 +31,7 @@ Optional parameters:
   this number of points. Min=2, Max=3000.
 * `filter` – boolean. If `true`, the returned track will be filtered, applicable only for LBS tracks. It is `false` 
 by default.
+* `split` – boolean. Default=`true`. If `false`, all tracks will be merged into single one, and response will contain parking points.
 
 The platform will reply:
 
@@ -68,7 +69,6 @@ The platform will reply:
 * `precision` - optional int. Precision in meters.
 * `gsm_lbs` - optional boolean. `true` if location detected by GSM LBS.
 * `parking` - optional boolean. `true` if point does not belong to track.
-* `split` – boolean. If `true`, split tracks by folders with start/end placemarks and track line. Default `false`.
 
 You can also [download](../resources/tracking/track/index.md#download) a KML file. 
 You could use this file with map services. 
@@ -83,3 +83,4 @@ curl -X POST '{{ extra.api_example_url }}/track/download' \
 All parameters are identical with track/read with the except of one new optional parameters:
 
 * `format` – string. File format, "kml" or "kmz". Default is "kml".
+* `split` – boolean. If `true`, split tracks by folders with start/end placemarks and track line. Default `false`.

--- a/docs/backend-api/how-to/how-to-create-a-rule.md
+++ b/docs/backend-api/how-to/how-to-create-a-rule.md
@@ -20,9 +20,9 @@ Necessary parameters for this call. Availability of some parameters depends on u
 
 * `name` - A string containing a name of created rule.
 * `description` - A string containing rule's description.
-* `zone_ids` - An array of int. A list of zones to bind where the rule will work. Leave it empty if rule should work 
+* `zone_ids` - An int array. A list of zones to bind where the rule will work. Leave it empty if rule should work 
 everywhere. Parameter `zone_ids` is not allowed for rule `offline` and required for `route` and `inoutzone` rule types.
-* `trackers` - An array of int. A list of tracker ids belong to user for which the rule will work.
+* `trackers` - An int array. A list of tracker ids belong to user for which the rule will work.
 * `type` - A string containing one of pre-defined types of rules. See [rule types](../resources/tracking/tracker/rules/rule_types.md).
 * `primary_text` - A string with primary text of rule notification when condition is `true`.
 * `secondary_text` - An optional string with secondary text of rule notification when condition is `false`. The availability of 
@@ -62,7 +62,7 @@ Unbinding works similarly. When a rule is not necessary for some devices, [unbin
 Necessary parameters for both calls the same.
  
 * `rule_id` - An id of a rule. You can get ids using the [rule/list](../resources/tracking/tracker/rules/rule.md#list) call.
-* `trackers` - An array of int. List trackers' IDs. Trackers which do not exist, owned by other user or deleted ignored without errors.
+* `trackers` - An int array. List trackers' IDs. Trackers which do not exist, owned by other user or deleted ignored without errors.
  
 API requests:
  

--- a/docs/backend-api/how-to/how-to-create-a-rule.md
+++ b/docs/backend-api/how-to/how-to-create-a-rule.md
@@ -71,7 +71,7 @@ API requests:
  ```shell
  curl -X POST '{{ extra.api_example_url }}/tracker/rule/bind' \
      -H 'Content-Type: application/json' \
-     -d '{"hash": "a6aa75587e5c59c32d347da438505fc3", "rule_id": "123", "trackers": [265489]}'
+     -d '{"hash": "a6aa75587e5c59c32d347da438505fc3", "rule_id": 123, "trackers": [265489]}'
  ```
 
 === "Unbind"
@@ -79,7 +79,7 @@ API requests:
  ```shell
  curl -X POST '{{ extra.api_example_url }}/tracker/rule/unbind' \
      -H 'Content-Type: application/json' \
-     -d '{"hash": "a6aa75587e5c59c32d347da438505fc3", "rule_id": "123", "trackers": [265489]}'
+     -d '{"hash": "a6aa75587e5c59c32d347da438505fc3", "rule_id": 123, "trackers": [265489]}'
  ```
 
 ### Update

--- a/docs/backend-api/how-to/how-to-create-a-rule.md
+++ b/docs/backend-api/how-to/how-to-create-a-rule.md
@@ -1,6 +1,6 @@
 ---
 title: How to use rules
-description: Rules used to set up conditions according to which the system logs the events and sends notifications to user.
+description: How to work with rules that used to set up conditions according to which the system logs the events and sends notifications to user.
 ---
 
 # How to use rules
@@ -8,82 +8,33 @@ description: Rules used to set up conditions according to which the system logs 
 Rules used to set up conditions according to which the system logs the events and sends notifications to user.
 
 When a server receives a new portion of data from the device, it checks whether the conditions set are true 
-or false for this data. If they are true, the server generates an event in history, logs it and immediately sends SMS or
- Email, as specified.
+or false for this data. If they are true, the server generates an event in history, logs it and immediately sends SMS,
+push message or email and saves event in history.
  
 ### Create
 
-Let's create a rule with conditions according to which the platform will generate events and schedule intervals when this
- rule should work. The user must have access to rule update.
+To start work the rule must be created. Let's create a rule with conditions according to which the platform will generate events and schedule intervals when this
+ rule should work using the [rule/create](../resources/tracking/tracker/rules/rule.md#create). The user must have access to rule update.
 
-#### parameters
+Necessary parameters for this call. Availability of some parameters depends on used rule type:
 
-| name | description | type |
-| :------ | :------ | :----- |
-| name | The name of created rule. | string |
-| description | Rule's description. | string |
-| zone_ids | List of zones to bind where the rule will work. Leave it empty if rule should work everywhere. | array of int |
-| trackers | List of tracker ids belong to user for which the rule will work. | array of int |
-| type | One of pre-defined types of rules. See [rule types](../resources/tracking/tracker/rules/rule_types.md). | string enum |
-| primary_text | Primary text of rule notification when condition is true. | string |
-| secondary_text | Secondary text of rule notification when condition is false. | string |
-| param | A common parameter that responsible for integer conditions. See [rule types](../resources/tracking/tracker/rules/rule_types.md). | int |
-| alerts | An object with destinations for notifications. Described below. | JSON object |
-| suspended | Starts and stops the rule. `true` if the rule suspended. | boolean |
-| schedule | An optional object. Configures the time - when the rule works. Described below. | JSON object |
-| extended_params | An optional object. Specified for concrete rule type. See [rule types](../resources/tracking/tracker/rules/rule_types.md). | JSON object |
+* `name` - A string containing a name of created rule.
+* `description` - A string containing rule's description.
+* `zone_ids` - An array of int. A list of zones to bind where the rule will work. Leave it empty if rule should work 
+everywhere. Parameter `zone_ids` is not allowed for rule `offline` and required for `route` and `inoutzone` rule types.
+* `trackers` - An array of int. A list of tracker ids belong to user for which the rule will work.
+* `type` - A string containing one of pre-defined types of rules. See [rule types](../resources/tracking/tracker/rules/rule_types.md).
+* `primary_text` - A string with primary text of rule notification when condition is `true`.
+* `secondary_text` - An optional string with secondary text of rule notification when condition is `false`. The availability of 
+this parameter depends on rule type. Not every rule has the `secondary_text`.
+* `param` - An optional integer. A common parameter that responsible for integer conditions. 
+The availability of this parameter depends on rule type. See [rule types](../resources/tracking/tracker/rules/rule_types.md). 
+* `alerts` - An object with destinations for notifications. Answers the question - who and how will receive notifications. Described in [rule object](../resources/tracking/tracker/rules/rule.md).
+* `suspended` - A boolean which starts and stops the rule. `true` if the rule suspended.
+* `schedule` - An optional object which configures the time - when the rule works. Described in [rule object](../resources/tracking/tracker/rules/rule.md).
+* `extended_params` - An optional object. Specified for concrete rule type. See [rule types](../resources/tracking/tracker/rules/rule_types.md).
 
-Alerts object:
-
-```json
-{
-  "sms_phones": ["98829991"],
-  "phones": ["98829991"],
-  "emails": ["example@test.com"],
-  "push_enabled": true,
-  "emergency": false
-}
-```
-
-* `sms_phones` - array of int. Phone numbers with country code and without "+" sign for SMS notifications.
-* `phones` - array of string. Phone numbers with country code and without "+" sign for voice calls.
-* `emails` - array of string. Emails for notifications.
-* `push_enabled` - boolean. If `true` push notifications available.
-* `emergency` - boolean. If `true` notifications will be marked as emergency with color and sound.
-
-Schedule object can be:
-
-* **weekly_schedule_interval**
-
-```json
-{
-  "type": "weekly",
-  "from": {
-    "weekday":1,
-    "time":"00:00:00"
-  },
-  "to": {
-    "weekday":7,
-    "time":"23:59:59"
-  },
-  "interval_id": 1
-}
-```
-
-* **fixed_schedule_interval**
-
-```json
-{
-  "type": "fixed",
-  "from": "2014-07-09 07:50:58",
-  "to": "2014-07-10 07:50:58",
-  "interval_id": 3
-}
-```
-
-* `date/time` and `local_time` types described at the [data types description section](../getting-started.md#data-types).
-
-#### example
+API request:
 
 === "cURL"
 
@@ -93,9 +44,7 @@ Schedule object can be:
         -d '{"hash": "a6aa75587e5c59c32d347da438505fc3", "rule": {"description": "", "type": "work_status_change", "primary_text": "status changed", "secondary_text": "", "alerts": {"push_enabled": true, "emails": ["example@gmail.com"], "emergency": false, "sms_phones": ["745494878945"], "phones": []}, "suspended": "false", "append_zone_title": "", "name": "Status changing", "trackers": [123456], "extended_params": {"emergency": false, "zone_limit_inverted": false, "status_ids": [319281,319282,319283]}, "param": "", "schedule": [{"from": {"weekday": 1, "time": "00:00:00"}, "to": {"weekday": 7,"time": "23:59:59"}, "type": "weekly"}], "zone_ids": [], "group_id": 1}}'
     ```
 
-#### response
-
-You will get created rule ID.
+You will get ID of created rule in response. 
 
 ```json
 {
@@ -104,24 +53,18 @@ You will get created rule ID.
 }
 ```
 
-#### errors
-
-* 204 - Entity not found – when associated zone is not exist.
-
 ### Bind/Unbind
 
-When a rule created, bind devices to it. For example, a newly registered device must have the same rule. Unnecessary
+When a rule created, [bind](../resources/tracking/tracker/rules/rule.md#bind) devices to it. For example, a newly registered device must have the same rule. Unnecessary
 to create another rule. Bind this device to an already existing rule.
-Unbinding works similarly. When a rule is not necessary for some devices, unbind them without deleting rules.
+Unbinding works similarly. When a rule is not necessary for some devices, [unbind](../resources/tracking/tracker/rules/rule.md#unbind) them without deleting rules.
 
-#### parameters
+Necessary parameters for both calls the same.
  
-| name | description | type |
-| :------ | :------ | :----- |
-| rule_id | Id of a rule. You can get ids using the [rule/list](../resources/tracking/tracker/rules/rule.md#list) call. | int |
-| trackers | Ids of trackers. Trackers which do not exist, owned by other user or deleted ignored without errors. | array of int |
+* `rule_id` - An id of a rule. You can get ids using the [rule/list](../resources/tracking/tracker/rules/rule.md#list) call.
+* `trackers` - An array of int. List trackers' IDs. Trackers which do not exist, owned by other user or deleted ignored without errors.
  
-#### examples
+API requests:
  
 === "Bind"
 
@@ -138,43 +81,17 @@ Unbinding works similarly. When a rule is not necessary for some devices, unbind
      -H 'Content-Type: application/json' \
      -d '{"hash": "a6aa75587e5c59c32d347da438505fc3", "rule_id": "123", "trackers": [265489]}'
  ```
- 
-#### response
-
-You will get status of request.
-
-```json
-{
-    "success": true
-}
-```
 
 ### Update
 
 If the rule must be updated, for example, one more phone number must be added for SMS notifications, you can use the 
-rule/update call. It is much better than deleting an existing rule and creating a new one.
+[rule/update](../resources/tracking/tracker/rules/rule.md#update) call. It is much better than deleting an existing rule and creating a new one.
 
-#### parameters
+List of necessary parameters is the same as in [rule/create](#create) call plus `id` parameter.
 
-All parameters must be in the request.
+* `id` - An integer with id of the updating rule. You can get ids using the [rule/list](../resources/tracking/tracker/rules/rule.md#list) call.
 
-| name | description | type |
-| :------ | :------ | :----- |
-| id | Id of a rule. You can get ids using the [rule/list](../resources/tracking/tracker/rules/rule.md#list) call. | int |
-| name | The name of created rule. | string |
-| description | Rule's description. | string |
-| zone_ids | List of zones to bind where the rule will work. Leave it empty if rule should work everywhere. | array of int |
-| trackers | List of tracker ids belong to user for which the rule will work. | array of int |
-| type | One of pre-defined types of rules. See [rule types](../resources/tracking/tracker/rules/rule_types.md). | string enum |
-| primary_text | Primary text of rule notification when condition is true. | string |
-| secondary_text | Secondary text of rule notification when condition is false. | string |
-| param | A common parameter that responsible for integer conditions. See [rule types](../resources/tracking/tracker/rules/rule_types.md). | int |
-| alerts | An object with destinations for notifications. Described [above](#create). | JSON object |
-| suspended | Starts and stops the rule. `true` if the rule suspended. | boolean |
-| schedule | An optional object. Configures the time - when the rule works. Described [above](#create). | JSON object |
-| extended_params | An optional object. Specified for concrete rule type. See [rule types](../resources/tracking/tracker/rules/rule_types.md). | JSON object |
-
-#### example
+API request:
 
 === "cURL"
 
@@ -186,10 +103,10 @@ All parameters must be in the request.
  
 ### Suspend
 
-To suspend the rule use the rule/update call and change only one parameter `suspended` to `true`. All other parameters 
-should be in the call without changes.
+To suspend the rule use the [rule/update](../resources/tracking/tracker/rules/rule.md#update) call and change only one parameter `suspended` to `true`. All other parameters 
+should present in the call without changes.
  
-#### example
+API request:
 
 === "cURL"
 

--- a/docs/backend-api/how-to/how-to-create-a-rule.md
+++ b/docs/backend-api/how-to/how-to-create-a-rule.md
@@ -1,6 +1,6 @@
 ---
 title: How to use rules
-description: How to work with rules that used to set up conditions according to which the system logs the events and sends notifications to user.
+description: Rules used to set up conditions according to which the system logs the events and sends notifications to user.
 ---
 
 # How to use rules
@@ -8,33 +8,82 @@ description: How to work with rules that used to set up conditions according to 
 Rules used to set up conditions according to which the system logs the events and sends notifications to user.
 
 When a server receives a new portion of data from the device, it checks whether the conditions set are true 
-or false for this data. If they are true, the server generates an event in history, logs it and immediately sends SMS,
-push message or email and saves event in history.
+or false for this data. If they are true, the server generates an event in history, logs it and immediately sends SMS or
+ Email, as specified.
  
 ### Create
 
-To start work the rule must be created. Let's create a rule with conditions according to which the platform will generate events and schedule intervals when this
- rule should work using the [rule/create](../resources/tracking/tracker/rules/rule.md#create). The user must have access to rule update.
+Let's create a rule with conditions according to which the platform will generate events and schedule intervals when this
+ rule should work. The user must have access to rule update.
 
-Necessary parameters for this call. Availability of some parameters depends on used rule type:
+#### parameters
 
-* `name` - A string containing a name of created rule.
-* `description` - A string containing rule's description.
-* `zone_ids` - An array of int. A list of zones to bind where the rule will work. Leave it empty if rule should work 
-everywhere. Parameter `zone_ids` is not allowed for rule `offline` and required for `route` and `inoutzone` rule types.
-* `trackers` - An array of int. A list of tracker ids belong to user for which the rule will work.
-* `type` - A string containing one of pre-defined types of rules. See [rule types](../resources/tracking/tracker/rules/rule_types.md).
-* `primary_text` - A string with primary text of rule notification when condition is `true`.
-* `secondary_text` - An optional string with secondary text of rule notification when condition is `false`. The availability of 
-this parameter depends on rule type. Not every rule has the `secondary_text`.
-* `param` - An optional integer. A common parameter that responsible for integer conditions. 
-The availability of this parameter depends on rule type. See [rule types](../resources/tracking/tracker/rules/rule_types.md). 
-* `alerts` - An object with destinations for notifications. Answers the question - who and how will receive notifications. Described in [rule object](../resources/tracking/tracker/rules/rule.md).
-* `suspended` - A boolean which starts and stops the rule. `true` if the rule suspended.
-* `schedule` - An optional object which configures the time - when the rule works. Described in [rule object](../resources/tracking/tracker/rules/rule.md).
-* `extended_params` - An optional object. Specified for concrete rule type. See [rule types](../resources/tracking/tracker/rules/rule_types.md).
+| name | description | type |
+| :------ | :------ | :----- |
+| name | The name of created rule. | string |
+| description | Rule's description. | string |
+| zone_ids | List of zones to bind where the rule will work. Leave it empty if rule should work everywhere. | array of int |
+| trackers | List of tracker ids belong to user for which the rule will work. | array of int |
+| type | One of pre-defined types of rules. See [rule types](../resources/tracking/tracker/rules/rule_types.md). | string enum |
+| primary_text | Primary text of rule notification when condition is true. | string |
+| secondary_text | Secondary text of rule notification when condition is false. | string |
+| param | A common parameter that responsible for integer conditions. See [rule types](../resources/tracking/tracker/rules/rule_types.md). | int |
+| alerts | An object with destinations for notifications. Described below. | JSON object |
+| suspended | Starts and stops the rule. `true` if the rule suspended. | boolean |
+| schedule | An optional object. Configures the time - when the rule works. Described below. | JSON object |
+| extended_params | An optional object. Specified for concrete rule type. See [rule types](../resources/tracking/tracker/rules/rule_types.md). | JSON object |
 
-API request:
+Alerts object:
+
+```json
+{
+  "sms_phones": ["98829991"],
+  "phones": ["98829991"],
+  "emails": ["example@test.com"],
+  "push_enabled": true,
+  "emergency": false
+}
+```
+
+* `sms_phones` - array of int. Phone numbers with country code and without "+" sign for SMS notifications.
+* `phones` - array of string. Phone numbers with country code and without "+" sign for voice calls.
+* `emails` - array of string. Emails for notifications.
+* `push_enabled` - boolean. If `true` push notifications available.
+* `emergency` - boolean. If `true` notifications will be marked as emergency with color and sound.
+
+Schedule object can be:
+
+* **weekly_schedule_interval**
+
+```json
+{
+  "type": "weekly",
+  "from": {
+    "weekday":1,
+    "time":"00:00:00"
+  },
+  "to": {
+    "weekday":7,
+    "time":"23:59:59"
+  },
+  "interval_id": 1
+}
+```
+
+* **fixed_schedule_interval**
+
+```json
+{
+  "type": "fixed",
+  "from": "2014-07-09 07:50:58",
+  "to": "2014-07-10 07:50:58",
+  "interval_id": 3
+}
+```
+
+* `date/time` and `local_time` types described at the [data types description section](../getting-started.md#data-types).
+
+#### example
 
 === "cURL"
 
@@ -44,7 +93,9 @@ API request:
         -d '{"hash": "a6aa75587e5c59c32d347da438505fc3", "rule": {"description": "", "type": "work_status_change", "primary_text": "status changed", "secondary_text": "", "alerts": {"push_enabled": true, "emails": ["example@gmail.com"], "emergency": false, "sms_phones": ["745494878945"], "phones": []}, "suspended": "false", "append_zone_title": "", "name": "Status changing", "trackers": [123456], "extended_params": {"emergency": false, "zone_limit_inverted": false, "status_ids": [319281,319282,319283]}, "param": "", "schedule": [{"from": {"weekday": 1, "time": "00:00:00"}, "to": {"weekday": 7,"time": "23:59:59"}, "type": "weekly"}], "zone_ids": [], "group_id": 1}}'
     ```
 
-You will get ID of created rule in response. 
+#### response
+
+You will get created rule ID.
 
 ```json
 {
@@ -53,25 +104,31 @@ You will get ID of created rule in response.
 }
 ```
 
+#### errors
+
+* 204 - Entity not found – when associated zone is not exist.
+
 ### Bind/Unbind
 
-When a rule created, [bind](../resources/tracking/tracker/rules/rule.md#bind) devices to it. For example, a newly registered device must have the same rule. Unnecessary
+When a rule created, bind devices to it. For example, a newly registered device must have the same rule. Unnecessary
 to create another rule. Bind this device to an already existing rule.
-Unbinding works similarly. When a rule is not necessary for some devices, [unbind](../resources/tracking/tracker/rules/rule.md#unbind) them without deleting rules.
+Unbinding works similarly. When a rule is not necessary for some devices, unbind them without deleting rules.
 
-Necessary parameters for both calls the same.
+#### parameters
  
-* `rule_id` - An id of a rule. You can get ids using the [rule/list](../resources/tracking/tracker/rules/rule.md#list) call.
-* `trackers` - An array of int. List trackers' IDs. Trackers which do not exist, owned by other user or deleted ignored without errors.
+| name | description | type |
+| :------ | :------ | :----- |
+| rule_id | Id of a rule. You can get ids using the [rule/list](../resources/tracking/tracker/rules/rule.md#list) call. | int |
+| trackers | Ids of trackers. Trackers which do not exist, owned by other user or deleted ignored without errors. | array of int |
  
-API requests:
+#### examples
  
 === "Bind"
 
  ```shell
  curl -X POST '{{ extra.api_example_url }}/tracker/rule/bind' \
      -H 'Content-Type: application/json' \
-     -d '{"hash": "a6aa75587e5c59c32d347da438505fc3", "rule_id": 123, "trackers": [265489]}'
+     -d '{"hash": "a6aa75587e5c59c32d347da438505fc3", "rule_id": "123", "trackers": [265489]}'
  ```
 
 === "Unbind"
@@ -79,19 +136,45 @@ API requests:
  ```shell
  curl -X POST '{{ extra.api_example_url }}/tracker/rule/unbind' \
      -H 'Content-Type: application/json' \
-     -d '{"hash": "a6aa75587e5c59c32d347da438505fc3", "rule_id": 123, "trackers": [265489]}'
+     -d '{"hash": "a6aa75587e5c59c32d347da438505fc3", "rule_id": "123", "trackers": [265489]}'
  ```
+ 
+#### response
+
+You will get status of request.
+
+```json
+{
+    "success": true
+}
+```
 
 ### Update
 
 If the rule must be updated, for example, one more phone number must be added for SMS notifications, you can use the 
-[rule/update](../resources/tracking/tracker/rules/rule.md#update) call. It is much better than deleting an existing rule and creating a new one.
+rule/update call. It is much better than deleting an existing rule and creating a new one.
 
-List of necessary parameters is the same as in [rule/create](#create) call plus `id` parameter.
+#### parameters
 
-* `id` - An integer with id of the updating rule. You can get ids using the [rule/list](../resources/tracking/tracker/rules/rule.md#list) call.
+All parameters must be in the request.
 
-API request:
+| name | description | type |
+| :------ | :------ | :----- |
+| id | Id of a rule. You can get ids using the [rule/list](../resources/tracking/tracker/rules/rule.md#list) call. | int |
+| name | The name of created rule. | string |
+| description | Rule's description. | string |
+| zone_ids | List of zones to bind where the rule will work. Leave it empty if rule should work everywhere. | array of int |
+| trackers | List of tracker ids belong to user for which the rule will work. | array of int |
+| type | One of pre-defined types of rules. See [rule types](../resources/tracking/tracker/rules/rule_types.md). | string enum |
+| primary_text | Primary text of rule notification when condition is true. | string |
+| secondary_text | Secondary text of rule notification when condition is false. | string |
+| param | A common parameter that responsible for integer conditions. See [rule types](../resources/tracking/tracker/rules/rule_types.md). | int |
+| alerts | An object with destinations for notifications. Described [above](#create). | JSON object |
+| suspended | Starts and stops the rule. `true` if the rule suspended. | boolean |
+| schedule | An optional object. Configures the time - when the rule works. Described [above](#create). | JSON object |
+| extended_params | An optional object. Specified for concrete rule type. See [rule types](../resources/tracking/tracker/rules/rule_types.md). | JSON object |
+
+#### example
 
 === "cURL"
 
@@ -103,10 +186,10 @@ API request:
  
 ### Suspend
 
-To suspend the rule use the [rule/update](../resources/tracking/tracker/rules/rule.md#update) call and change only one parameter `suspended` to `true`. All other parameters 
-should present in the call without changes.
+To suspend the rule use the rule/update call and change only one parameter `suspended` to `true`. All other parameters 
+should be in the call without changes.
  
-API request:
+#### example
 
 === "cURL"
 

--- a/docs/backend-api/how-to/how-to-work-with-notifications.md
+++ b/docs/backend-api/how-to/how-to-work-with-notifications.md
@@ -77,13 +77,13 @@ sorting by time if necessary.
 
 The necessary parameters for the call:
 
-* `trackers` - an array of int. A list of tracker ids belong to user for which events will be searched.
+* `trackers` - an int array. A list of tracker ids belong to user for which events will be searched.
 * `from` - a string containing the start date/time for searching.
 * `to` - a string containing the end date/time of searching. Must be after "from" date.
 
 Optional parameters that could be used to get more specific information:
 
-* `events` - an array of string with necessary event types. All other events will be ignored. Default: all. To get the 
+* `events` - a string array with necessary event types. All other events will be ignored. Default: all. To get the 
 list of events use [tracker/history/type](../resources/commons/history/history_type.md#list) call. 
 * `limit` - integer with a maximum count of entries in result.
 * `ascending` - a boolean where sort ascending by time when it is `true` and descending when `false`.

--- a/docs/backend-api/how-to/how-to-work-with-notifications.md
+++ b/docs/backend-api/how-to/how-to-work-with-notifications.md
@@ -1,5 +1,5 @@
 ---
-title: How to work with notifications
+title: How to use rules
 description: How to work with notifications that can be received by triggering alerts.
 ---
 
@@ -8,7 +8,7 @@ description: How to work with notifications that can be received by triggering a
 Notifications important part of the tracking. A [created a rule](./how-to-create-a-rule.md) will track triggering of 
 specified conditions and send events to emails and phones. It sends notifications to know that a condition triggered. 
 Sometimes, necessary to store those notifications and history entries to use them in special reports, or they can be 
-used for scripts build on APIs. Let's see how to work with them.
+used for scripts build on APIs. Lets ses how to work with them.
 
 ## Obtain a list of history entries
 
@@ -20,7 +20,7 @@ The call contains only two optional parameters:
 
 * `limit` - int with a maximum count of entries in response
 * `from` - a string containing the start date/time for searching. Without this parameter you will get all unread entries
- for the last 30 days.
+ for last year.
 
 In our example we need to obtain no more than 100 entries for last month. If today is 26-01-2021 then API request will be:
 

--- a/docs/backend-api/how-to/how-to-work-with-notifications.md
+++ b/docs/backend-api/how-to/how-to-work-with-notifications.md
@@ -1,5 +1,5 @@
 ---
-title: How to use rules
+title: How to work with notifications
 description: How to work with notifications that can be received by triggering alerts.
 ---
 
@@ -8,7 +8,7 @@ description: How to work with notifications that can be received by triggering a
 Notifications important part of the tracking. A [created a rule](./how-to-create-a-rule.md) will track triggering of 
 specified conditions and send events to emails and phones. It sends notifications to know that a condition triggered. 
 Sometimes, necessary to store those notifications and history entries to use them in special reports, or they can be 
-used for scripts build on APIs. Lets ses how to work with them.
+used for scripts build on APIs. Let's see how to work with them.
 
 ## Obtain a list of history entries
 
@@ -20,7 +20,7 @@ The call contains only two optional parameters:
 
 * `limit` - int with a maximum count of entries in response
 * `from` - a string containing the start date/time for searching. Without this parameter you will get all unread entries
- for last year.
+ for the last 30 days.
 
 In our example we need to obtain no more than 100 entries for last month. If today is 26-01-2021 then API request will be:
 

--- a/docs/backend-api/resources/billing/bill.md
+++ b/docs/backend-api/resources/billing/bill.md
@@ -29,7 +29,7 @@ API path: `/bill`.
     * `created` – but not settled.
     * `settled`.
     * `canceled`.
-* `positions` - array of string. List of position names. Usually contains one element for a bill.
+* `positions` - string array. List of position names. Usually contains one element for a bill.
 * `link` - string. URL to order.
 
 ### create

--- a/docs/backend-api/resources/billing/bill.md
+++ b/docs/backend-api/resources/billing/bill.md
@@ -23,9 +23,9 @@ API path: `/bill`.
 ```
 
 * `order_id` - int. Unique bill id.
-* `created` - [date/time](../../getting-started.md#data-types). When the bill created.
+* `created` - string date/time. When the bill created.
 * `sum` - float. A bill sum in default currency of the panel.
-* `status` - [enum](../../getting-started.md#data-types). Bill order status. Can be one of:
+* `status` - string enum. Bill order status. Can be one of:
     * `created` – but not settled.
     * `settled`.
     * `canceled`.

--- a/docs/backend-api/resources/billing/bill.md
+++ b/docs/backend-api/resources/billing/bill.md
@@ -23,9 +23,9 @@ API path: `/bill`.
 ```
 
 * `order_id` - int. Unique bill id.
-* `created` - string date/time. When the bill created.
+* `created` - [date/time](../../getting-started.md#data-types). When the bill created.
 * `sum` - float. A bill sum in default currency of the panel.
-* `status` - string enum. Bill order status. Can be one of:
+* `status` - [enum](../../getting-started.md#data-types). Bill order status. Can be one of:
     * `created` – but not settled.
     * `settled`.
     * `canceled`.

--- a/docs/backend-api/resources/billing/payment_system.md
+++ b/docs/backend-api/resources/billing/payment_system.md
@@ -35,7 +35,7 @@ API path: `/payment_system`.
 * `currency` - string. 3-letter ISO 4217 currency code.
 * `payment_code` - optional string. Code for payments.
 * `subscription_code` - string. Subscription code. The same as "payment_code" for 2Checkout (formerly Avangate) but for subscriptions.
-* `methods` - optional array of string. List of available payment methods (it may be empty).
+* `methods` - optional string array. List of available payment methods (it may be empty).
 * `prices` - optional object with prices. For type == `ios_inapp` only.
 
 ### list

--- a/docs/backend-api/resources/billing/subscription.md
+++ b/docs/backend-api/resources/billing/subscription.md
@@ -92,7 +92,7 @@ List active [2Checkout](https://www.2checkout.com) [formerly Avangate](http://ww
 * `reference` - string. Internal 2Checkout (formerly Avangate) subscription code. Pass it to /subscription/avangate/cancel.
 * `code` - string. 2Checkout (formerly Avangate) product code.
 * `quantity` - int. Count.
-* `expiration_date` - [date/time](../../getting-started.md#data-types). Next renew date/time.
+* `expiration_date` - string date/time. Next renew date/time.
 
 #### errors
 

--- a/docs/backend-api/resources/billing/subscription.md
+++ b/docs/backend-api/resources/billing/subscription.md
@@ -92,7 +92,7 @@ List active [2Checkout](https://www.2checkout.com) [formerly Avangate](http://ww
 * `reference` - string. Internal 2Checkout (formerly Avangate) subscription code. Pass it to /subscription/avangate/cancel.
 * `code` - string. 2Checkout (formerly Avangate) product code.
 * `quantity` - int. Count.
-* `expiration_date` - string date/time. Next renew date/time.
+* `expiration_date` - [date/time](../../getting-started.md#data-types). Next renew date/time.
 
 #### errors
 

--- a/docs/backend-api/resources/billing/tariff/index.md
+++ b/docs/backend-api/resources/billing/tariff/index.md
@@ -21,7 +21,7 @@ API call to get device's tariffs available to user.
     "price": 13.0,
     "early_change_price": 23.0,
     "device_limit": 1000,
-    "has_reports" : true,
+    "has_reports" : true
     "paas_free": false,
     "store_period": "12m",
     "features": [
@@ -38,7 +38,7 @@ API call to get device's tariffs available to user.
 * `name` - string. Tariff's label.
 * `group_id` - int. Group of tariffs. User can change the tariff only on the tariff in the same group.
 * `active` - boolean. Tariff is active if `true`. User can change the tariff only on the active tariff.
-* `type` - [enum](../../../getting-started.md#data-types). Tariff type. Can be "monthly", "everyday", "activeday".
+* `type` - string enum. Tariff type. Can be "monthly", "everyday", "activeday".
 * `price` - double. Price per month for "monthly" and "everyday" tariff or price per "active" day for "activeday" tariff.
 * `early_change_price` - double. Price of change tariff from current to other. With the last change in less than 
 30 days (**tariff.freeze.period** config option). When not passed or "null" user cannot change tariff frequently.
@@ -60,7 +60,7 @@ Listed only tariffs [available for user's legal type](#tariff).
 
 | name | description | type|
 | :------ | :------ | :-----|
-| device_type | Type of devices. Can be `tracker`, `camera` or `socket`. | [enum](../../../getting-started.md#data-types) |
+| device_type | Type of devices. Can be `tracker`, `camera` or `socket`. | string enum |
 
 #### examples
 
@@ -92,7 +92,7 @@ Listed only tariffs [available for user's legal type](#tariff).
        "price": 13.0,
        "early_change_price": 23.0,
        "device_limit": 1000,
-       "has_reports" : true,
+       "has_reports" : true
        "paas_free": false,
        "store_period": "12m",
        "features": [

--- a/docs/backend-api/resources/billing/tariff/index.md
+++ b/docs/backend-api/resources/billing/tariff/index.md
@@ -38,7 +38,7 @@ API call to get device's tariffs available to user.
 * `name` - string. Tariff's label.
 * `group_id` - int. Group of tariffs. User can change the tariff only on the tariff in the same group.
 * `active` - boolean. Tariff is active if `true`. User can change the tariff only on the active tariff.
-* `type` - string enum. Tariff type. Can be "monthly", "everyday", "activeday".
+* `type` - [enum](../../../getting-started.md#data-types). Tariff type. Can be "monthly", "everyday", "activeday".
 * `price` - double. Price per month for "monthly" and "everyday" tariff or price per "active" day for "activeday" tariff.
 * `early_change_price` - double. Price of change tariff from current to other. With the last change in less than 
 30 days (**tariff.freeze.period** config option). When not passed or "null" user cannot change tariff frequently.
@@ -60,7 +60,7 @@ Listed only tariffs [available for user's legal type](#tariff).
 
 | name | description | type|
 | :------ | :------ | :-----|
-| device_type | Type of devices. Can be `tracker`, `camera` or `socket`. | string enum |
+| device_type | Type of devices. Can be `tracker`, `camera` or `socket`. | [enum](../../../getting-started.md#data-types) |
 
 #### examples
 

--- a/docs/backend-api/resources/billing/tariff/index.md
+++ b/docs/backend-api/resources/billing/tariff/index.md
@@ -46,7 +46,7 @@ API call to get device's tariffs available to user.
 * `has_reports` - boolean. `true` if reports allowed, `false` otherwise.
 * `paas_free` - boolean. `true` if this tariff is free for PaaS owner, `false` otherwise.
 * `store_period` - string. Data storage period, e.g. "2h" (2 hours), "3d" (3 days), "5m" (5 months), "1y" (one year).
-* `features` - array of string. Available features for the user.
+* `features` - string array. Available features for the user.
 * `map_filter` - object with available maps for the user.
     * `exclusion` - boolean. If `true` maps from `values` will be not active, `false` - maps from values will be active.
 

--- a/docs/backend-api/resources/billing/tariff/tariff_tracker.md
+++ b/docs/backend-api/resources/billing/tariff/tariff_tracker.md
@@ -108,7 +108,7 @@ List tariffs on which user can switch the passed tracker (even when tariff last 
        "price": 13.0,
        "early_change_price": 23.0,
        "device_limit": 1000,
-       "has_reports" : true,
+       "has_reports" : true
        "paas_free": false,
        "store_period": "12m",
        "features": [

--- a/docs/backend-api/resources/billing/transaction.md
+++ b/docs/backend-api/resources/billing/transaction.md
@@ -13,26 +13,26 @@ API call to get user's billing transactions.
 
 ```json
 {
-"description": "Recharge bonus balance during tracker registration",
-"type": "bonus_charge",
-"subtype": "register",
-"timestamp": "2021-01-28 08:16:40",
-"user_id": 12203,
-"dealer_id": 5001,
-"tracker_id": 303126,
-"amount": -10.0000,
-"new_balance": 800.0000,
-"old_balance": 810.0000,
-"bonus_amount": 10.0000,
-"new_bonus": 10.0000,
-"old_bonus": 0.0000
+    "description": "Recharge bonus balance during tracker registration",
+    "type": "bonus_charge",
+    "subtype": "register",
+    "timestamp": "2021-01-28 08:16:40",
+    "user_id": 12203,
+    "dealer_id": 5001,
+    "tracker_id": 303126,
+    "amount": -10.0000,
+    "new_balance": 800.0000,
+    "old_balance": 810.0000,
+    "bonus_amount": 10.0000,
+    "new_bonus": 10.0000,
+    "old_bonus": 0.0000
 }
 ```
 
 * `description` - string. Transaction description.
-* `type` - string enum. Type of transaction.
-* `subtype` - string enum. Subtype of transaction.
-* `timestamp` - string date/time. When transaction created.
+* `type` - [enum](../../getting-started.md#data-types). Type of transaction.
+* `subtype` - [enum](../../getting-started.md#data-types). Subtype of transaction.
+* `timestamp` - [date/time](../../getting-started.md#data-types). When transaction created.
 * `user_id` - int. ID of a user which made a transaction.
 * `dealer_id` - int. ID of a dealer.
 * `tracker_id` - int. Tracker id. 0 if transaction not associated with tracker.
@@ -53,8 +53,8 @@ Gets list of user's billing transactions for the specified period.
 
 | name | description | type|
 | :------ | :------ | :-----|
-| from | Start date/time for searching. | string date/time |
-| to | End date/time for searching. Must be after `from` date. | string date/time |
+| from | Start date/time for searching. | [date/time](../../getting-started.md#data-types) |
+| to | End date/time for searching. Must be after `from` date. | [date/time](../../getting-started.md#data-types) |
 | limit | Optional. Maximum number of returned transactions. | int |
 
 #### example

--- a/docs/backend-api/resources/billing/transaction.md
+++ b/docs/backend-api/resources/billing/transaction.md
@@ -13,26 +13,26 @@ API call to get user's billing transactions.
 
 ```json
 {
-    "description": "Recharge bonus balance during tracker registration",
-    "type": "bonus_charge",
-    "subtype": "register",
-    "timestamp": "2021-01-28 08:16:40",
-    "user_id": 12203,
-    "dealer_id": 5001,
-    "tracker_id": 303126,
-    "amount": -10.0000,
-    "new_balance": 800.0000,
-    "old_balance": 810.0000,
-    "bonus_amount": 10.0000,
-    "new_bonus": 10.0000,
-    "old_bonus": 0.0000
+"description": "Recharge bonus balance during tracker registration",
+"type": "bonus_charge",
+"subtype": "register",
+"timestamp": "2021-01-28 08:16:40",
+"user_id": 12203,
+"dealer_id": 5001,
+"tracker_id": 303126,
+"amount": -10.0000,
+"new_balance": 800.0000,
+"old_balance": 810.0000,
+"bonus_amount": 10.0000,
+"new_bonus": 10.0000,
+"old_bonus": 0.0000
 }
 ```
 
 * `description` - string. Transaction description.
-* `type` - [enum](../../getting-started.md#data-types). Type of transaction.
-* `subtype` - [enum](../../getting-started.md#data-types). Subtype of transaction.
-* `timestamp` - [date/time](../../getting-started.md#data-types). When transaction created.
+* `type` - string enum. Type of transaction.
+* `subtype` - string enum. Subtype of transaction.
+* `timestamp` - string date/time. When transaction created.
 * `user_id` - int. ID of a user which made a transaction.
 * `dealer_id` - int. ID of a dealer.
 * `tracker_id` - int. Tracker id. 0 if transaction not associated with tracker.
@@ -53,8 +53,8 @@ Gets list of user's billing transactions for the specified period.
 
 | name | description | type|
 | :------ | :------ | :-----|
-| from | Start date/time for searching. | [date/time](../../getting-started.md#data-types) |
-| to | End date/time for searching. Must be after `from` date. | [date/time](../../getting-started.md#data-types) |
+| from | Start date/time for searching. | string date/time |
+| to | End date/time for searching. Must be after `from` date. | string date/time |
 | limit | Optional. Maximum number of returned transactions. | int |
 
 #### example

--- a/docs/backend-api/resources/commons/data.md
+++ b/docs/backend-api/resources/commons/data.md
@@ -31,8 +31,8 @@ If `parse_header` is set to `true`, first row of the uploaded file will be treat
 ```
 
 * `file_id` - string. Unique file id.
-* `header` - optional array of string. List of files' headers.
-* `preview` - array of string. First N rows of file.
+* `header` - optional string array. List of files' headers.
+* `preview` - string array. First N rows of file.
 
 #### errors
 

--- a/docs/backend-api/resources/commons/dealer.md
+++ b/docs/backend-api/resources/commons/dealer.md
@@ -109,7 +109,7 @@ It doesn't need authentication and available in **UNAUTHORIZED** access level.
     * `locale` - [enum](../../getting-started.md#data-types). Default locale of the dealer.
     * `demo_login` - string. Dealer's login for demo user or empty string if no demo user available.
     * `demo_password` - string. Dealer's password for demo user or empty string if no demo user available.
-    * `maps` - array of string. List of available maps, 
+    * `maps` - string array. List of available maps, 
     e.g. `["roadmap", "cdcom", "osm", "wikimapia", "yandexpublic", "hybrid", "satellite"]`.
     * `default_map` - object. Default map settings.
     * `type` - [enum](../../getting-started.md#data-types). Default map type.
@@ -143,7 +143,7 @@ It doesn't need authentication and available in **UNAUTHORIZED** access level.
     * `enable_cameras` - boolean. If `true`, camera monitoring interface is available for dealer's users.
     * `tracker_model_filter` - object. A filter which describes tracker models available for registration.
     * `exclusion` - boolean. If `true` models in the `values` will be excluded.
-    * `values` - array of string. If it is empty - all models available.
+    * `values` - string array. If it is empty - all models available.
     * `internal` - object with additional options.
     * `light_registration` - boolean. If `true` use "very simple" registration with demo tracker.
     * `demo_tracker_source_id` - int. An id of tracker created on `light_registration`.
@@ -151,7 +151,7 @@ It doesn't need authentication and available in **UNAUTHORIZED** access level.
     * `no_register_commands` - boolean. If `true` then do not send commands to devices on activation.
 * `demo_ends` - string. A date when demo for this dealer ends. Is null when dealer is not on Trial tariff.
 * `premium_gis` - boolean. If `true` dealer has Premium GIS package.
-* `features` - array of string. Set of the allowed features for a dealer (all list see below in "Dealer features").
+* `features` - string array. Set of the allowed features for a dealer (all list see below in "Dealer features").
 
 #### Dealer features
 

--- a/docs/backend-api/resources/commons/entity/index.md
+++ b/docs/backend-api/resources/commons/entity/index.md
@@ -39,7 +39,7 @@ API path: `/entity`.
 `layout` - object describes layout of fields for entity.
     `sections` - array of objects. Each section can contain one or more fields. At least one section must exist in a layout.
     `label` - string. Name of section.
-    `field_order` - array of string. Built-in fields and ids of custom fields (as strings).
+    `field_order` - string array. Built-in fields and ids of custom fields (as strings).
 
 **entity types**:
 

--- a/docs/backend-api/resources/commons/feedback.md
+++ b/docs/backend-api/resources/commons/feedback.md
@@ -24,7 +24,7 @@ API path: `/feedback`.
 * `text` - string. Feedback text. May not be null.
 * `useragent` - optional string. Information about the browser of user.
 * `platform` - optional string. Information about the platform of user.
-* `screenshots` - optional array of string. base64-encoded data:url image, example: data:image/jpeg;base64,`[encoded image]`.
+* `screenshots` - optional string array. base64-encoded data:url image, example: data:image/jpeg;base64,`[encoded image]`.
 * `log` - optional log file. Contains log of the browser.
 
 ### send_email

--- a/docs/backend-api/resources/commons/history/history_tracker.md
+++ b/docs/backend-api/resources/commons/history/history_tracker.md
@@ -18,10 +18,10 @@ and `to` date/time sorted by **time** field.
 
 | name | description | type |
 | :----- | :-----  | :----- |
-| trackers | List of tracker's ids. | array of int |
+| trackers | List of tracker's ids. | int array |
 | from | Start date/time for searching. | string [date/time](../../../getting-started.md#data-types) |
 | to | End date/time for searching. Must be after "from" date. | string [date/time](../../../getting-started.md#data-types) |
-| events | Optional. Default: all. List of history types. | array of string |
+| events | Optional. Default: all. List of history types. | string array |
 | limit | Optional. Default: [maxHistoryLimit](../../../getting-started.md#constants). Max count of entries in result. | int |
 | ascending | Optional. Default: `true`. Sort ascending by time when it is `true` and descending when `false`. | boolean |
 

--- a/docs/backend-api/resources/commons/plugin/index.md
+++ b/docs/backend-api/resources/commons/plugin/index.md
@@ -32,7 +32,7 @@ API path: `/plugin`.
 * `filter` - object. A model filter which describes to which device models this plugin is applicable.
     * `exclusion` - boolean. If `true`, "models" lists models NOT supported by this plugin, if `false`, "models" 
     contains all supported models.
-    * `values` - array of string. List of the regexes for models which are (not) supported by this plugin.
+    * `values` - string array. List of the regexes for models which are (not) supported by this plugin.
 * `parameters` - plugin-specific parameters as JSON object. This field omitted if it's `null` (and it is `null` most of the time).
 
 #### Example

--- a/docs/backend-api/resources/commons/plugin/report_plugins.md
+++ b/docs/backend-api/resources/commons/plugin/report_plugins.md
@@ -92,7 +92,7 @@ Plugin-specific parameters:
 | show_mileage | Adds mileage to the report if `true`. | boolean |
 | show_not_visited_zones | Will show non visited zones if `true`. | boolean |
 | min_minutes_in_zone | Minimum minutes in a zone to start determining visit. If the device was in a zone less than a specified time - the visit not count. | int |
-| zone_ids | List of zone ids. | array of int |
+| zone_ids | List of zone ids. | int array |
 | hide_charts| If `true`, charts will be hidden. | boolean |
 
 ### POI visits report
@@ -112,7 +112,7 @@ Plugin-specific parameters:
 | show_mileage | Adds mileage to the report if `true`. | boolean |
 | show_not_visited_places | Will show non visited POIs if `true`. | boolean |
 | min_minutes_in_place | Minimum minutes in a place to start determining visit. If the device was in a place less than a specified time - the visit not count. | int |
-| place_ids | List of place ids. | array of int |
+| place_ids | List of place ids. | int array |
 | hide_charts| If `true`, charts will be hidden. | boolean |
 
 ### Car security report
@@ -492,7 +492,7 @@ Plugin-specific parameters:
 | hide_empty_tabs | If `true`, empty tabs will be hidden. | boolean |
 | show_seconds | If `true` timestamps will be with seconds. | boolean |
 | group_by_type | Groups events by type if `true`. | boolean |
-| event_types | A list of event types that will be considered. | array of string |
+| event_types | A list of event types that will be considered. | string array |
 
 * the object with all `event_types` is:
 

--- a/docs/backend-api/resources/commons/report/report_schedule.md
+++ b/docs/backend-api/resources/commons/report/report_schedule.md
@@ -51,7 +51,7 @@ API path: `/report/schedule`.
 * `id` - int. Schedule id, ignored on create.
 * `enabled` - boolean. `true` if the scheduled report enabled.
 * `period` - string. Report period, "Xm" | "w" | "d" | "y".
-* `emails` - optional array of string. List of emails.
+* `emails` - optional string array. List of emails.
 * `email_format` - [enum](../../../getting-started.md#data-types). Can be "pdf" | "xls".
 * `sending_time` - optional string. Local time for sending reports, default "00:00:00", hourly granularity.
 * `fire_time` - optional string. Last schedule fire time, ignored on create/update.

--- a/docs/backend-api/resources/commons/report/report_tracker.md
+++ b/docs/backend-api/resources/commons/report/report_tracker.md
@@ -102,8 +102,8 @@ Requests a report generation with the specified parameters.
 | to | A string containing date/time in `yyyy-MM-dd HH:mm:ss` format (in user's timezone). Specified date must be after "from" date. | string |
 | title | Report title. Default title will be used if null. | string |
 | geocoder | Which geocoder to use. See [geocoder/](../../tracking/geocoder.md). | string |
-| trackers | List of trackers' ids to be included in report (if report is by trackers). | array of int |
-| employees | List of employees' ids to be included in report (if report is by employees). | array of int |
+| trackers | List of trackers' ids to be included in report (if report is by trackers). | int array |
+| employees | List of employees' ids to be included in report (if report is by employees). | int array |
 | time_filter | An object which contains everyday time and weekday limits for processed data, e.g. `{"to":"18:00", "from":"12:00", "weekdays":[1,2,3,4,5]}`. | JSON object |
 | plugin | A plugin object (see below). | JSON object |
 
@@ -242,11 +242,11 @@ Returns info about all available generated or in-progress reports.
 * `time_filter` - object.
     * `from` - string. Control time "from" of day.
     * `to` - string. Control time "to" of day.
-    * `weekdays` - array of int. Control "weekdays" of the report. Can be 1 - 7.
+    * `weekdays` - int array. Control "weekdays" of the report. Can be 1 - 7.
 * `title` - string. Report title.
 * `id` - int. Report id which can be used to retrieve or download report.
 * `parameters` - object with report parameters.
-    * `trackers` - array of int. List of tracker ids used for report.
+    * `trackers` - int array. List of tracker ids used for report.
     * `plugins` - array of objects. List of parameters for all plugins which were used to generate report.
     * `locale_info` - object with information about the locale, timezone, and measurement system used for the report.
 * `percent` - int. Report readiness in percent.

--- a/docs/backend-api/resources/commons/subuser/security_group.md
+++ b/docs/backend-api/resources/commons/subuser/security_group.md
@@ -26,7 +26,7 @@ API path: `/subuser/security_group/`.
 * `id` - int. Group id, can be null (when creating new security group).
 * `label` - string. Group label.
 * `privileges` - object containing privileges of group.
-    * `rights` - array of string. A set of rights granted to security group (see below).
+    * `rights` - string array. A set of rights granted to security group (see below).
     * `store_period` - optional string. Period of viewing history in legacy duration format, e.g. "2h" (2 hours), 
     "3d" (3 days), "5m" (5 months), "1y" (one year).
 

--- a/docs/backend-api/resources/commons/subuser/tracker.md
+++ b/docs/backend-api/resources/commons/subuser/tracker.md
@@ -21,7 +21,7 @@ Gives access for sub-user to the specified trackers.
 | name | description | type |
 | :----- | :-----  | :----- |
 | subuser_id | Id of the sub-user belonging to current account. | int |
-| trackers | List of tracker ids to associate with the specified sub-user. All trackers must belong to current master user. | array of int |
+| trackers | List of tracker ids to associate with the specified sub-user. All trackers must belong to current master user. | int array |
 
 #### examples
 
@@ -92,7 +92,7 @@ Gets a list of tracker ids to which this sub-user has access.
 }
 ```
 
-* `list` - array of int. List of tracker ids to which this sub-user has access.
+* `list` - int array. List of tracker ids to which this sub-user has access.
 
 #### errors
 
@@ -112,7 +112,7 @@ Disables access for sub-user to the specified trackers.
 | name | description | type |
 | :----- | :-----  | :----- |
 | subuser_id | Id of the sub-user belonging to current account. | int |
-| trackers | List of tracker ids to associate with the specified sub-user. All trackers must belong to current master user. | array of int |
+| trackers | List of tracker ids to associate with the specified sub-user. All trackers must belong to current master user. | int array |
 
 #### examples
 

--- a/docs/backend-api/resources/commons/tag/index.md
+++ b/docs/backend-api/resources/commons/tag/index.md
@@ -170,8 +170,8 @@ Search entities that bound with all of specified tags.
 
 | name | description | type |
 | :----- | :-----  | :----- |
-| tag_ids | List of tag IDs to search. | array of int |
-| entity_types | Optional. List of [tagged entity types](#tag) to filter. | array of string |
+| tag_ids | List of tag IDs to search. | int array |
+| entity_types | Optional. List of [tagged entity types](#tag) to filter. | string array |
 
 #### examples
 

--- a/docs/backend-api/resources/commons/timezone.md
+++ b/docs/backend-api/resources/commons/timezone.md
@@ -50,7 +50,7 @@ Information about all supported timezones for the specified locale. Does not req
 * `base_offset` - double. Base timezone offset in hours, e.g. 10 means UTC +10. May be negative or fractional!
 * `dst_offset` - int. DST offset in hours (0 if no DST rules for this timezone).
 * `country_code` - string. ISO country code for the timezone.
-* `alt_ids` - array of string. List of strings, optional, alternative timezone IDs.
+* `alt_ids` - string array. List of strings, optional, alternative timezone IDs.
 
 #### errors
 

--- a/docs/backend-api/resources/commons/user/audit/audit_log.md
+++ b/docs/backend-api/resources/commons/user/audit/audit_log.md
@@ -49,11 +49,11 @@ Gets list of audit records available for current user.
 | :----- | :-----  | :----- |
 | from | Include audit objects recorded after this date. | [date/time](../../../../getting-started.md#data-types) |
 | to | Include audits before this date. | [date/time](../../../../getting-started.md#data-types) |
-| subuser_ids | Optional. Include audits for specific sub-users. | array of int |
-| actions | Optional. Include audits for specific actions only. | array of string |
+| subuser_ids | Optional. Include audits for specific sub-users. | int array |
+| actions | Optional. Include audits for specific actions only. | string array |
 | limit | Pagination. Maximum number of audit records to return. | int |
 | offset | Pagination. Get audits starting from. | int |
-| sort | Optional. Set of sort options. Each option is a pair of property name and sorting direction, e.g. `["action_date=acs", "user=desc"]`. | array of string |
+| sort | Optional. Set of sort options. Each option is a pair of property name and sorting direction, e.g. `["action_date=acs", "user=desc"]`. | string array |
 | grouping | Optional. Group log by "user", "action_date", "action" or don't group "default". | [enum](../../../../getting-started.md#data-types) |
  
 Properties available for sorting by:

--- a/docs/backend-api/resources/commons/user/index.md
+++ b/docs/backend-api/resources/commons/user/index.md
@@ -110,11 +110,11 @@ API path: `/user`.
     * `master` - object. Returned only if current user is sub-user. All fields have same meaning as in "user_info", but for 
     master user's account.
     * `tariff_restrictions` - tariff restrictions object, for more info see [user/get_tariff_restrictions](#get_tariff_restrictions).
-        * `allowed_maps` - array of string. List of allowed maps.
+        * `allowed_maps` - string array. List of allowed maps.
     * `premium_gis` - boolean. `true` if a dealer has premium GIS tariff.
-    * `features` - array of string. Set of allowed [Dealer features](../dealer.md#dealer-features).
+    * `features` - string array. Set of allowed [Dealer features](../dealer.md#dealer-features).
     * `privileges` - object only returned for sub-users. Describes effective sub-user privileges. 
-    * `rights` - array of string. A set of rights granted to sub-user. Described in [security group rights](../subuser/security_group.md#security-group-rights).
+    * `rights` - string array. A set of rights granted to sub-user. Described in [security group rights](../subuser/security_group.md#security-group-rights).
 
 ### activate
 
@@ -303,7 +303,7 @@ Only session `hash`.
 }
 ```
 
-* `allowed_maps` - array of string. List of allowed maps.
+* `allowed_maps` - string array. List of allowed maps.
 
 #### errors
 

--- a/docs/backend-api/resources/commons/user/settings/index.md
+++ b/docs/backend-api/resources/commons/user/settings/index.md
@@ -37,7 +37,7 @@ API path: `/user/settings`.
 }
 ```
 
-* `emails` - array of string. List of emails to send alert message about balance. Empty array means disclaimer of notifications.
+* `emails` - string array. List of emails to send alert message about balance. Empty array means disclaimer of notifications.
 
 `file_storage_settings` type is JSON object:
 

--- a/docs/backend-api/resources/field_service/checkin.md
+++ b/docs/backend-api/resources/field_service/checkin.md
@@ -163,11 +163,11 @@ Gets marker entries on a map for trackers and for the specified time interval.
 
 | name | description | type |
 | :--- | :--- | :--- |
-| trackers | Optional. Array of tracker ids. All trackers must not be deleted or blocked (if list_blocked=false). If not specified, all available trackers will be used as value. | array of int |
+| trackers | Optional. Array of tracker ids. All trackers must not be deleted or blocked (if list_blocked=false). If not specified, all available trackers will be used as value. | int array |
 | from | Optional. Start date/time for searching. | date/time |
 | to | Optional. End date/time for searching. Must be after "from" date. | date/time |
-| conditions | Optional. Search conditions to apply to list. See [Search conditions](../commons/entity/search_conditions.md). Allowed fields are `employee`, `location`, `marker_time`, `comment`. | array of string |
-| sort | Optional, offset, default is 0. List of sort expressions. See below. | array of string |
+| conditions | Optional. Search conditions to apply to list. See [Search conditions](../commons/entity/search_conditions.md). Allowed fields are `employee`, `location`, `marker_time`, `comment`. | string array |
+| sort | Optional, offset, default is 0. List of sort expressions. See below. | string array |
 | location | Optional, location with radius, inside which check-ins must reside | Location JSON. For example, ```{ "lat": 56.823777, "lng": 60.594164, "radius": 350 }``` | 
 | limit | Optional. Max number of records to return | int |
 | offset | Optional, offset (starting index of first returned record), default is 0. | int |
@@ -240,7 +240,7 @@ Deletes check-ins with the specified id-s.
 
 | name | description | type |
 | :--- | :--- | :--- |
-| checkin_ids | List of check-in ids.  | array of int |
+| checkin_ids | List of check-in ids.  | int array |
 
 #### examples
 

--- a/docs/backend-api/resources/field_service/employee/index.md
+++ b/docs/backend-api/resources/field_service/employee/index.md
@@ -54,7 +54,7 @@ via [avatar/upload](./avatar.md#upload).
 * `location` - optional object. Location associated with this employee, should be valid or null.
     * `address` - string. Address of the location.
 * `personnel_number` - optional string. Max length is 15.
-* `tags` - array of int. List of tag ids.
+* `tags` - int array. List of tag ids.
 
 ## API actions
 
@@ -278,7 +278,7 @@ Convert batch of tab-delimited employees and return list of checked employees wi
 | :--- | :--- | :--- |
 | batch | Batch of tab-delimited employees. | string |
 | file_id | Preloaded file ID. | string |
-| fields | Optional. Array of field names. Default is `["first_name", "middle_name", "last_name", "email", "phone"]`. | array of string |
+| fields | Optional. Array of field names. Default is `["first_name", "middle_name", "last_name", "email", "phone"]`. | string array |
 | geocoder | Geocoder type. | string |
 | default_radius | Optional. Radius for point in meters. Default is 100. | int |
 

--- a/docs/backend-api/resources/field_service/form/field-types.md
+++ b/docs/backend-api/resources/field_service/form/field-types.md
@@ -251,7 +251,7 @@ File attachment. For example, document or spreadsheet.
 }
 ```
 
-* `file_ids` - array of int. Ids of the file which should be attached to this form field as value. Files must be 
+* `file_ids` - int array. Ids of the file which should be attached to this form field as value. Files must be 
 uploaded before form submission.
 
 ### Photo
@@ -279,7 +279,7 @@ Photograph attachment.
 }
 ```
 
-* `file_ids` - array of int. Ids of the files which should be attached to this form field as value. Files must be
+* `file_ids` - int array. Ids of the files which should be attached to this form field as value. Files must be
  uploaded before form submission. Only image files allowed.
 
 ### Signature

--- a/docs/backend-api/resources/field_service/place/index.md
+++ b/docs/backend-api/resources/field_service/place/index.md
@@ -47,7 +47,7 @@ Thus, field employee can view all places assigned to him to visit them, etc.
 * `fields` - optional object. A map, each key of which is a custom field id *as a string*. See [entity/fields](../../commons/entity/fields.md)
 * `label` - string. The name of the place.
 * `description` - optional string. Description of the place.
-* `tags` - optional array of int. A list of tag_ids. Non-empty.
+* `tags` - optional int array. A list of tag_ids. Non-empty.
 * `external_id` - optional string. Max length 32.
 
 ## API actions
@@ -121,7 +121,7 @@ Get places belonging to user.
 
 |name |description |type |
 |:--- |:--- |:--- |
-| place_ids | Optional. List of place IDs. | array of int |
+| place_ids | Optional. List of place IDs. | int array |
 | filter | Optional. Filter for all built-in and custom fields. If used with conditions, both filter and conditions must match for every returned place. | string |
 | conditions | Optional. Search conditions to apply to list. Array of search conditions, see [Search conditions](../../commons/entity/search_conditions.md). | array of objects |
 | order_by | Optional. Built-in or custom field according to which output should be sorted. Entity field name, e.g "label" (builtin) or "123" (field id as string, see [entity/](../../commons/entity/index.md). | string |
@@ -299,7 +299,7 @@ Converts batch of tab-delimited places and return list of checked places with er
 | :--- | :--- | :--- |
 | batch | Batch of tab-delimited places. | string |
 | file_id | Preloaded file ID. | string |
-| fields | Optional. Array of field names, default is `["label", "address", "lat", "lng", "radius", "description", "tags"]`. | array of strings |
+| fields | Optional. Array of field names, default is `["label", "address", "lat", "lng", "radius", "description", "tags"]`. | string array |
 | geocoder | Geocoder type. | string |
 | default_radius | Optional. Radius for point in meters. Default is 100. | int |
 
@@ -339,7 +339,7 @@ If `file_id` is set – `batch` parameter will be ignored.
 
 * `list` - a list of <checked_place> objects.
     * `errors` - optional array of objects. Errors found during check.
-    * `tag_names` - optional array of strings. Tag names of the place.
+    * `tag_names` - optional string array. Tag names of the place.
 * `limit_exceeded` - boolean. `true` if given batch constrained by a limit.
 
 #### errors

--- a/docs/backend-api/resources/field_service/task/checkpoint.md
+++ b/docs/backend-api/resources/field_service/task/checkpoint.md
@@ -57,7 +57,7 @@ Every route consists of checkpoints. Using these actions, you can manipulate che
 * `arrival_date` - [date/time](../../../getting-started.md#data-types). Wen tracker has arrived to the checkpoint zone. *IGNORED* in checkpoint/create, checkpoint/update.
 * `stay_duration` - int. Duration of stay in the checkpoint zone, seconds.
 * `origin` - string. Checkpoint origin. *IGNORED* in checkpoint/create, checkpoint/update.
-* `tags` - array of int. List of tag ids.
+* `tags` - int array. List of tag ids.
 * `form` - [form object](../form/index.md#form-object). If present.
 * `form_template_id` - int. An id of form template. Used in create and update actions only if `create_form` parameter is `true` in them.
 
@@ -156,7 +156,7 @@ Get checkpoints belonging to user with given ids
 
 | name | description | type | 
 | :--- | :--- | :--- |
-| checkpoint_ids | IDs of checkpoints, e.g. `[1,2]`. | array of int |
+| checkpoint_ids | IDs of checkpoints, e.g. `[1,2]`. | int array |
 
 #### examples
 

--- a/docs/backend-api/resources/field_service/task/index.md
+++ b/docs/backend-api/resources/field_service/task/index.md
@@ -69,7 +69,7 @@ it's available for viewing by app user. User will also receive notifications of 
 * `arrival_date` - [date/time](../../../getting-started.md#data-types). When tracker has arrived to the task zone. *IGNORED* in create/update.
 * `stay_duration` - int. Duration of stay in the task zone, seconds.
 * `origin` - string. Task origin. *IGNORED* in create/update.
-* `tags` - array of int. List of tag ids.
+* `tags` - int array. List of tag ids.
 * `form` - [form object](../form/index.md#form-object). If present.
 * `form_template_id` - int. An id of form template. Used in create and update actions only if `create_form` parameter is `true` in them.
 * `fields` - optional object. A map, each key of which is a custom field id *as a string*. See [entity/fields](../../commons/entity/fields.md)
@@ -132,15 +132,15 @@ Converts batch of tab-delimited tasks and return list of checked tasks with erro
 | name | description | type | 
 | :--- | :--- | :--- |
 | batch | Batch of tab-delimited tasks. | string |
-| fields | Optional. Array of field names, default is `["label", "from", "to", "address", "lat", "lng", "description"]`. | array of string |
+| fields | Optional. Array of field names, default is `["label", "from", "to", "address", "lat", "lng", "description"]`. | string array |
 | geocoder | Geocoder type. | [enum](../../../getting-started.md#data-types) |
 | default_radius | Optional. Radius for point, default is 100. | int |
 | default_max_delay | Optional. Max delay for tasks, default is 0. | int |
 | default_duration | Optional. Duration for task in minutes, default is 60. | int
 | default_min_stay_duration | Optional. Minimal stay duration for task in minutes, default is 0. | int |
 | location_check_mode | Optional. One of "no_check", "entity_location", "parent_location" | [enum](../../../getting-started.md#data-types) |
-| employee_ids | Optional. List of employee Ids to automatic assign | array of int |
-| vehicle_ids | Optional. List of vehicle Ids to automatic assign | array of int |
+| employee_ids | Optional. List of employee Ids to automatic assign | int array |
+| vehicle_ids | Optional. List of vehicle Ids to automatic assign | int array |
 
 In case of location_check_mode==entity_location – vehicle_ids will be ignored.
 
@@ -346,14 +346,14 @@ Gets all task belonging to user with optional filtering.
 | name | description | type | 
 | :--- | :--- | :--- |
 | external_id | Optional. External task ID for search. | string |
-| statuses | Optional. Default all. List of task statuses, e.g. `["unassigned","failed"]`. | array of string |
-| trackers | Optional. Ids of the trackers to which task assigned. | array of int |
+| statuses | Optional. Default all. List of task statuses, e.g. `["unassigned","failed"]`. | string array |
+| trackers | Optional. Ids of the trackers to which task assigned. | int array |
 | from | Optional. Show tasks which are actual AFTER this date, e.g. "2020-07-01 00:00:00". | [date/time](../../../getting-started.md#data-types) |
 | to | Optional. Show tasks which are actual BEFORE this date, e.g. "2020-07-01 00:00:00". | [date/time](../../../getting-started.md#data-types) |
 | conditions | Optional. Search conditions to apply to list. Array of search conditions. | array of [SearchCondition](../../commons/entity/search_conditions.md) |
 | filter | Optional. Filter for all built-in and custom fields. If used with conditions, both filter and conditions must match for every returned task. | string |
-| filters | Optional. Filters for task label, description or address. | array of string |
-| tag_ids | Optional. Tag IDs assigned to the task. | array of int |
+| filters | Optional. Filters for task label, description or address. | string array |
+| tag_ids | Optional. Tag IDs assigned to the task. | int array |
 | location | Optional. Location with radius, inside which task zone centers must reside. Example: ```{ "lat": 56.823777, "lng": 60.594164, "radius": 350 }``` | Location JSON |
 | offset | Optional. Offset from start of the found tasks for pagination. | int |
 | limit | Optional. Limit of the found tasks for pagination. | int |

--- a/docs/backend-api/resources/field_service/task/route/index.md
+++ b/docs/backend-api/resources/field_service/task/route/index.md
@@ -43,8 +43,8 @@ completed with warnings or failed.
 * `status` - string. A route status. *IGNORED* in route/create, route/update.
 * `status_change_date` - [date/time](../../../../getting-started.md#data-types). When route status changed. *IGNORED* in route/create, route/update.
 * `origin` - string. A route origin. *IGNORED* in route/create, route/update.
-* `tags` - array of int. List of tag ids.
-* `checkpoint_ids` - array of int. List of route checkpoint ids in order of execution. *IGNORED* in route/create.
+* `tags` - int array. List of tag ids.
+* `checkpoint_ids` - int array. List of route checkpoint ids in order of execution. *IGNORED* in route/create.
 
 ## API actions
 
@@ -187,7 +187,7 @@ If there is nothing to return, then parameter "external_id_counts" will not be p
 }
 ```
 
-* `checkpoint_ids` - array of int. A list of route checkpoint ids in order of execution.
+* `checkpoint_ids` - int array. A list of route checkpoint ids in order of execution.
 * `external_id_counts` - optional object. Count of external ids.
  
 #### errors
@@ -244,7 +244,7 @@ Get all routes belonging to user with optional filtering.
 | name | description | type | 
 | :--- | :--- | :--- |
 | statuses | Optional. List of task statuses, e.g. `["unassigned","failed"]`. Default all. | [enum](../../../../getting-started.md#data-types) array |
-| trackers | Optional. List of `tracker_id` to which task assigned. | array of int |
+| trackers | Optional. List of `tracker_id` to which task assigned. | int array |
 | from | Optional. Show tasks which are actual AFTER this date, e.g. "2020-06-01 00:00:00". | [date/time](../../../../getting-started.md#data-types) |
 | to | Optional. Show tasks which are actual BEFORE this date, e.g. "2020-07-01 00:00:00". | [date/time](../../../../getting-started.md#data-types) |
 | filter | Optional. Filter for task label and description. If **trackers**, **filter**, **from** or **to** is not passed or _null_ then appropriate condition not used to filter results. | string |

--- a/docs/backend-api/resources/field_service/task/schedule/index.md
+++ b/docs/backend-api/resources/field_service/task/schedule/index.md
@@ -53,7 +53,7 @@ replaced with `from_time`, `duration` and `parameters`.
 * `min_stay_duration` - int. Minimum duration of stay in task zone for task completion, minutes.
 * `min_arrival_duration` - int. Visits less than these values will be ignored, minutes.
 * `parameters` - schedule parameters can be "weekdays" or "month_days". Described below.
-* `tags` - array of int. List of tag ids.
+* `tags` - int array. List of tag ids.
 * `form_template_id` - int. Form template id. Nullable.
 
 ## Route schedule entry
@@ -115,7 +115,7 @@ replaced with `from_time`, `duration` and `parameters`.
 * `min_arrival_duration` - int. Visits less than these values will be ignored, minutes.
 * `from_time` - string time. Time of day which defines start of the task within the days.
 * `duration` - int. Total duration in minutes between "from" and "to" for generated tasks.
-* `tags` - array of int. List of tag ids.
+* `tags` - int array. List of tag ids.
 * `form_template_id` - int. Form template id. Nullable.
 
 `<schedule_parameters>` can be one of the following:
@@ -129,7 +129,7 @@ replaced with `from_time`, `duration` and `parameters`.
 }
 ```
 
-    * `weekdays` - array of int. Week days on which tasks will be created (1 = Monday, ... 7 = Sunday)
+    * `weekdays` - int array. Week days on which tasks will be created (1 = Monday, ... 7 = Sunday)
     
 * month_days - task creation based on day of month.
 
@@ -140,7 +140,7 @@ replaced with `from_time`, `duration` and `parameters`.
 }
 ```
 
-    * `month_days` - array of int. Days of month on which tasks will be created (1..31).
+    * `month_days` - int array. Days of month on which tasks will be created (1..31).
 
 
 ## API actions
@@ -234,7 +234,7 @@ Also this call returns all unassigned task schedules.
 
 | name | description | type | 
 | :--- | :--- | :--- |
-| trackers | Optional. Ids of the trackers to which task schedule is assigned. | array of int |
+| trackers | Optional. Ids of the trackers to which task schedule is assigned. | int array |
 | filter | Optional. Filter for task schedule label and description. | string |
 
 #### examples

--- a/docs/backend-api/resources/field_service/task/schedule/proposal.md
+++ b/docs/backend-api/resources/field_service/task/schedule/proposal.md
@@ -19,7 +19,7 @@ Get all tasks and routes that will be created by schedule.
 
 | name | description | type | 
 | :--- | :--- | :--- |
-| trackers | Optional. Ids of the trackers to which task is assigned. | array of int |
+| trackers | Optional. Ids of the trackers to which task is assigned. | int array |
 | from | Show tasks that will be created AFTER this date, e.g. "2014-07-01 00:00:00", should not before now | [date/time](../../../../getting-started.md#data-types) |
 | to | Show tasks will be created BEFORE this date, e.g. "2014-07-01 00:00:00", should not before `from` | [date/time](../../../../getting-started.md#data-types) |
 | filter | Optional. Filter for task schedule label and description. | string |

--- a/docs/backend-api/resources/fleet/driver_journal/entry.md
+++ b/docs/backend-api/resources/fleet/driver_journal/entry.md
@@ -59,11 +59,11 @@ If there are no `entry_ids` in request, entries will be selected by intersecting
 | name | description | type |
 | :------ | :------ | :----- |
 | tracker_id | Id of the tracker (aka "object_id"). Tracker must belong to authorized user and not be blocked. | int |
-| entry_ids | Optional. Array of entry ids. | array of int |
+| entry_ids | Optional. Array of entry ids. | int array |
 | from | Optional. Include tracks which end after this date, e.g. "2020-10-13 00:00:00". | [date/time](../../../getting-started.md#data-types) |
 | to | Optional. Include tracks which end after this date, e.g. "2020-10-14 00:00:00". | [date/time](../../../getting-started.md#data-types) |
-| types | Optional. Types of the driver journal entry, e.g. `["work", "personal", "other"]`. | array of string |
-| sort | Optional. Set of sort options. Each option is a pair of column name and sorting direction, e.g. `["start_date=acs", "type=desc"]`. | array of string |
+| types | Optional. Types of the driver journal entry, e.g. `["work", "personal", "other"]`. | string array |
+| sort | Optional. Set of sort options. Each option is a pair of column name and sorting direction, e.g. `["start_date=acs", "type=desc"]`. | string array |
 
 * Possible columns of `sort` parameter:
 
@@ -191,7 +191,7 @@ Deletes driver journal entries.
 
 | name | description | type |
 | :------ | :------ | :----- |
-| entry_ids | Array of driver journal entries' ids. | array of int |
+| entry_ids | Array of driver journal entries' ids. | int array |
 
 #### examples
 
@@ -225,11 +225,11 @@ and `to` parameters).
 | name | description | type |
 | :------ | :------ | :----- |
 | tracker_id | Id of the tracker (aka "object_id"). Tracker must belong to authorized user and not be blocked. | int |
-| entry_ids | Optional. Array of entry ids. | array of int |
+| entry_ids | Optional. Array of entry ids. | int array |
 | from | Optional. Include tracks which end after this date, e.g. "2020-10-13 00:00:00". | [date/time](../../../getting-started.md#data-types) |
 | to | Optional. Include tracks which end after this date, e.g. "2020-10-14 00:00:00". | [date/time](../../../getting-started.md#data-types) |
-| types | Optional. Types of the driver journal entry, e.g. `["work", "personal", "other"]`. | array of string |
-| sort | Optional. Set of [sort options](#list). Each option is a pair of column name and sorting direction, e.g. `["start_date=acs", "type=desc"]`. | array of string |
+| types | Optional. Types of the driver journal entry, e.g. `["work", "personal", "other"]`. | string array |
+| sort | Optional. Set of [sort options](#list). Each option is a pair of column name and sorting direction, e.g. `["start_date=acs", "type=desc"]`. | string array |
 | add_filename_header | If `true` then Content-Disposition header will be appended to the response. Default value is `true`. | boolean |
 | format | File format: "pdf", "xls" and "xlsx" | string |
 | group_by | Optional. If specified, grouped entries will be in different sections of the table. | string |

--- a/docs/backend-api/resources/fleet/vehicle/index.md
+++ b/docs/backend-api/resources/fleet/vehicle/index.md
@@ -87,7 +87,7 @@ API path: `/vehicle`.
 * `free_insurance_valid_till` - string date. The date till free insurance valid.
 * `icon_id` - nullable int. Can only be updated via [avatar/assign](../vehicle/avatar.md#assign).
 * `avatar_file_name` - string. File name.
-* `tags` - array of int. List of tag ids.
+* `tags` - int array. List of tag ids.
 
 ???+ example "Subtypes:"
     ```
@@ -378,7 +378,7 @@ name | description | type
 --- | --- | ---
 batch | batch of tab-delimited vehicles. | String
 file_id | preloaded file ID | String
-fields | Optional, array of field names, default is `["label", "model", "reg_number", "fuel_grade"]` | array of strings
+fields | Optional, array of field names, default is `["label", "model", "reg_number", "fuel_grade"]` | string array
 geocoder | geocoder type | String
 
 

--- a/docs/backend-api/resources/fleet/vehicle/service_task/service_task.md
+++ b/docs/backend-api/resources/fleet/vehicle/service_task/service_task.md
@@ -25,7 +25,7 @@ Creates multiple service tasks.
 
 | name | description | type |
 | :------ | :------ | :----- |
-| vehicle_ids | List of vehicle ids. Task will be created for every vehicle.  | array of int |
+| vehicle_ids | List of vehicle ids. Task will be created for every vehicle.  | int array |
 | task | Service task to create. `vehicle_id` field in these objects should not be specified. | JSON object |
 
 A `task` object is:
@@ -80,13 +80,13 @@ A `task` object is:
         * `limit` - int. Task limit in hours.
         * `notification_interval` - int. Notify about task in specified number of hours.
 * `notifications` - notifications object.
-    * `sms_phones` - array of string. Phones where sms notifications should be sent. In the international format without
+    * `sms_phones` - string array. Phones where sms notifications should be sent. In the international format without
      `+` sign.
-    * `emails` - array of string. Email addresses where sms notifications should be sent.
+    * `emails` - string array. Email addresses where sms notifications should be sent.
     * `push_enabled` - boolean. If `true` push notifications enabled.
 * `repeat` - boolean. If `true` then new task will be created when current task done.
 * `unplanned` - boolean. If `true` service task is unplanned. For information only.
-* `file_ids` - array of int. One file will be specified in many service tasks. If one of the tasks will be deleted, 
+* `file_ids` - int array. One file will be specified in many service tasks. If one of the tasks will be deleted, 
 then file will remain in others. File will be deleted only when the last task with it will be deleted.
 
 #### example
@@ -169,13 +169,13 @@ A `task` object is:
         * `limit` - int. Task limit in hours.
         * `notification_interval` - int. Notify about task in specified number of hours.
 * `notifications` - notifications object.
-    * `sms_phones` - array of string. Phones where sms notifications should be sent. In the international format without
+    * `sms_phones` - string array. Phones where sms notifications should be sent. In the international format without
      `+` sign.
-    * `emails` - array of string. Email addresses where sms notifications should be sent.
+    * `emails` - string array. Email addresses where sms notifications should be sent.
     * `push_enabled` - boolean. If `true` push notifications enabled.
 * `repeat` - boolean. If `true` then new task will be created when current task done.
 * `unplanned` - boolean. If `true` service task is unplanned. For information only.
-* `file_ids` - array of int. One file will be specified in many service tasks. If one of the tasks will be deleted, 
+* `file_ids` - int array. One file will be specified in many service tasks. If one of the tasks will be deleted, 
 then file will remain in others. File will be deleted only when the last task with it will be deleted.
 
 #### example
@@ -213,7 +213,7 @@ Deletes a vehicle service task.
 | name | description | type |
 | :------ | :------ | :----- |
 | task_id | Optional. Id of service task. | int |
-| task_ids |  Optional. Ids of service tasks. | array of int |
+| task_ids |  Optional. Ids of service tasks. | int array |
 
 Either **task_id** or **task_ids** should be specified
 
@@ -390,13 +390,13 @@ List all service tasks of all user vehicles.
         * `limit` - int. Task limit in hours.
         * `notification_interval` - int. Notify about task in specified number of hours.
 * `notifications` - notifications object.
-    * `sms_phones` - array of string. Phones where sms notifications should be sent. In the international format wo
+    * `sms_phones` - string array. Phones where sms notifications should be sent. In the international format wo
      `+` sign.
-    * `emails` - array of string. Email addresses where sms notifications should be sent.
+    * `emails` - string array. Email addresses where sms notifications should be sent.
     * `push_enabled` - boolean. If `true` push notifications enabled.
 * `repeat` - boolean. If `true` then new task will be created when current task done.
 * `unplanned` - boolean. If `true` service task is unplanned. For information only.
-* `file_ids` - array of int. One file will be specified in many service tasks. If one of the tasks will be deleted, 
+* `file_ids` - int array. One file will be specified in many service tasks. If one of the tasks will be deleted, 
 then file will remain in others. File will be deleted only when the last task with it will be deleted.
 
 About [task status](#task-status) property.

--- a/docs/backend-api/resources/tracking/status/index.md
+++ b/docs/backend-api/resources/tracking/status/index.md
@@ -41,7 +41,7 @@ API base path: `/status/`
 * `label` - string. Human-readable label for the status listing.
 * `employee_controlled` - boolean. If `true` employees can change their own status, e.g. using mobile tracking app.
 * `supervisor_controlled` - boolean. If `true` supervisors can change status, e.g. using mobile monitoring app.
-* `entries` - array of int. List of IDs of statuses which belong to this listing. Order matters, and is preserved.
+* `entries` - int array. List of IDs of statuses which belong to this listing. Order matters, and is preserved.
 
 ### create
 

--- a/docs/backend-api/resources/tracking/status/tracker.md
+++ b/docs/backend-api/resources/tracking/status/tracker.md
@@ -85,7 +85,7 @@ Gets current assigned statuses for the specified trackers.
 
 | name | description | type| format |
 | :------ | :------ | :----- | :----- |
-| trackers | List of the tracker's IDs belonging to authorized user. | array of int | `[123456, 234567]` |
+| trackers | List of the tracker's IDs belonging to authorized user. | int array | `[123456, 234567]` |
 
 #### examples
 

--- a/docs/backend-api/resources/tracking/track/index.md
+++ b/docs/backend-api/resources/tracking/track/index.md
@@ -16,13 +16,13 @@ Downloads track points as KML/KMZ file for the specified track ID, tracker and t
 | name | description | type| format |
 | :------ | :------ | :----- | :----- |
 | tracker_id | Id of the tracker (aka "object_id"). Tracker must belong to authorized user and not be blocked. | int | `123456` |
-| from | From time in `yyyy-MM-dd HH:mm:ss` format (in user's timezone). | [date/time](../../../getting-started.md#data-types) | `"2020-09-23 03:24:00"` |
-| to | To time in `yyyy-MM-dd HH:mm:ss` format (in user's timezone). Specified date must be after "from" date. | [date/time](../../../getting-started.md#data-types) | `"2020-09-23 06:24:00"` |
+| from | From time in `yyyy-MM-dd HH:mm:ss` format (in user's timezone). | string date/time | `"2020-09-23 03:24:00"` |
+| to | To time in `yyyy-MM-dd HH:mm:ss` format (in user's timezone). Specified date must be after "from" date. | string date/time | `"2020-09-23 06:24:00"` |
 | track_ids | Optional. If specified, only points belonging to the specified tracks will be returned. If not, any valid track points between "from" and "to" will be returned. | array of int | `[123456, 234567]` | 
 | include_gsm_lbs | Optional. If `false` && track_ids not specified, GSM LBS points will be filtered out. Default=`true`. | boolean | `true` |
 | point_limit | Optional. If specified, the returned track will be simplified to contain this number of points. Min=2, Max=3000. If not specified, the server settings to decimates track will be used. | int | `300` |
 | filter | Optional. If specified, the returned track will be filtered, applicable only for LBS tracks now. | boolean | `true` |
-| format | File format, "kml" or "kmz", default is "kml". | [enum](../../../getting-started.md#data-types) | `"kml"` |
+| format | File format, "kml" or "kmz", default is "kml". | string enum | `"kml"` |
 | split | If `true`, split tracks by folders with start/end placemarks and track line. Default=`false`. | boolean | `false` |
 
 #### examples
@@ -63,10 +63,10 @@ Gets a list of track descriptions for the specified tracker and time period.
 | name | description | type| format |
 | :------ | :------ | :----- | :----- |
 | tracker_id | Id of the tracker (aka "object_id"). Tracker must belong to authorized user and not be blocked. | int | 123456 |
-| from | From time in `yyyy-MM-dd HH:mm:ss` format in user's timezone. | [date/time](../../../getting-started.md#data-types) | "2020-09-23 03:24:00" |
-| to | To time in `yyyy-MM-dd HH:mm:ss` format in user's timezone. Specified date must be after "from" date. | [date/time](../../../getting-started.md#data-types) | "2020-09-23 06:24:00" |
+| from | From time in `yyyy-MM-dd HH:mm:ss` format in user's timezone. | string date/time | "2020-09-23 03:24:00" |
+| to | To time in `yyyy-MM-dd HH:mm:ss` format in user's timezone. Specified date must be after "from" date. | string date/time | "2020-09-23 06:24:00" |
 | filter | Optional, default=`true`. If `true`, tracks which are too short (in terms of length and number of points) will be omitted from resulting list. | boolean | true |
-| split | Optional, default=`true`. If `false`, all tracks will be merged into single one.| boolean | true |
+| split | Optional, default=`true`. If `false`, all tracks will be merged into single one. | boolean | true |
 | include_gsm_lbs | Optional, default=`true`. If `false`, GSM LBS tracks will be filtered out. | boolean | true |
 | cluster_single_reports | Optional, default=`false`. If `true`, single point reports will be clustered by its coordinates. | boolean | false | 
 | count_events | Optional, default=`false`. If `true`, number of events occurred during each non-single point track will be returned. | true |
@@ -100,7 +100,7 @@ where <track_info> is either <regular>, <single_report>, <merged> or <cluster>:
 
 ```json
 {
-    "id": 123456,
+    "id": 123456
     "start_date": "2020-09-23 03:39:44",
     "start_address": "1255 6th Ave, New York, NY 10020, USA",
     "max_speed": 62,
@@ -117,10 +117,10 @@ where <track_info> is either <regular>, <single_report>, <merged> or <cluster>:
 ```
 
 * `id` - int. Track id.
-* `start_date` - [date/time](../../../getting-started.md#data-types). Track start date, in user's timezone e.g. "2011-06-18 03:39:44".
+* `start_date` - string date/time. Track start date, in user's timezone e.g. "2011-06-18 03:39:44".
 * `start_address` - string. Track start address.
 * `max_speed` - int. Maximum speed in km/h, e.g. 96.
-* `end_date` - [date/time](../../../getting-started.md#data-types). Track end date, in user's timezone e.g. "2011-06-18 05:18:36".
+* `end_date` - string date/time. Track end date, in user's timezone e.g. "2011-06-18 05:18:36".
 * `end_address` - string. Track end address.
 * `length` - float. Track length in kilometers, e.g. 85.5.
 * `points` - int. Total number of points in a track, e.g. 724.
@@ -128,7 +128,7 @@ where <track_info> is either <regular>, <single_report>, <merged> or <cluster>:
 * `event_count` - int. Number of events on this track. Field will be omitted if "count_events" is `false`.
 * `norm_fuel_consumed` - float. A consumed fuel on track, litres. Field will be omitted if no vehicle bound to tracker 
 or no normAvgFuelConsumption defined in a vehicle.
-* `type` - [enum](../../../getting-started.md#data-types). Used to distinguish this track type from the others. 
+* `type` - string enum. Used to distinguish this track type from the others. 
 * `gsm_lbs` - optional boolean. GSM LBS point flag.
 
 `single_report` object. Returned if device was creating reports in "interval" mode (e.g. M7 tracker in interval mode):
@@ -146,8 +146,8 @@ or no normAvgFuelConsumption defined in a vehicle.
 ```
 
 * `id` - int. Track id.
-* `type` - [enum](../../../getting-started.md#data-types). Used to distinguish this track type from the others. 
-* `start_date` - [date/time](../../../getting-started.md#data-types). Point creation date, in user's timezone e.g. "2011-06-18 03:39:44".
+* `type` - string enum. Used to distinguish this track type from the others. 
+* `start_date` - string date/time. Point creation date, in user's timezone e.g. "2011-06-18 03:39:44".
 * `start_address` - string. Point address.
 * `avg_speed` - int. Average speed in km/h, e.g. 70.
 * `gsm_lbs` - optional boolean. GSM LBS point flag.
@@ -160,7 +160,7 @@ or no normAvgFuelConsumption defined in a vehicle.
 {
     "start_date": "2020-09-24 03:39:44",
     "start_address": "1255 6th Ave, New York, NY 10020, USA",
-    "max_speed": 62,
+    "max_speed": 62
     "end_date": "2020-09-24 06:39:44",
     "end_address": "888 5th Ave, New York, NY 10021, USA",
     "length": 5.5,
@@ -173,10 +173,10 @@ or no normAvgFuelConsumption defined in a vehicle.
 }
 ```
 
-* `start_date` - [date/time](../../../getting-started.md#data-types). Track start date, in user's timezone e.g. "2011-06-18 03:39:44".
+* `start_date` - string date/time. Track start date, in user's timezone e.g. "2011-06-18 03:39:44".
 * `start_address` - string. Track start address.
 * `max_speed` - int. Maximum speed in km/h, e.g. 96.
-* `end_date` - [date/time](../../../getting-started.md#data-types). Track end date, in user's timezone e.g. "2011-06-18 05:18:36".
+* `end_date` - string date/time. Track end date, in user's timezone e.g. "2011-06-18 05:18:36".
 * `end_address` - string. Track end address.
 * `length` - float. Track length in kilometers, e.g. 85.5.
 * `points` - int. Total number of points in a track, e.g. 724.
@@ -184,7 +184,7 @@ or no normAvgFuelConsumption defined in a vehicle.
 * `event_count` - int. Number of events on this track. Field will be omitted if "count_events" is `false`.
 * `norm_fuel_consumed` - float. A consumed fuel on track, litres. Field will be omitted if no vehicle bound to tracker 
 or no normAvgFuelConsumption defined in a vehicle.
-* `type` - [enum](../../../getting-started.md#data-types). Used to distinguish this track type from the others. 
+* `type` - string enum. Used to distinguish this track type from the others. 
 * `gsm_lbs` - optional boolean. GSM LBS flag.
 
 `cluster` object. Only returned if "split" is set to `true`:
@@ -201,12 +201,12 @@ or no normAvgFuelConsumption defined in a vehicle.
 }
 ```
 
-* `start_date` - [date/time](../../../getting-started.md#data-types). Track start date, in user's timezone e.g. "2011-06-18 03:39:44".
+* `start_date` - string date/time. Track start date, in user's timezone e.g. "2011-06-18 03:39:44".
 * `start_address` - string. Track start address.
-* `end_date` - [date/time](../../../getting-started.md#data-types). Track end date, in user's timezone e.g. "2011-06-18 05:18:36".
+* `end_date` - string date/time. Track end date, in user's timezone e.g. "2011-06-18 05:18:36".
 * `precision` - optional int. Location precision, meters.
 * `points` - array of points in a cluster.
-* `type` - [enum](../../../getting-started.md#data-types). Used to distinguish this track type from the others. 
+* `type` - string enum. Used to distinguish this track type from the others. 
 * `gsm_lbs` - optional boolean. GSM LBS flag, true if cluster contains only GSM LBS points.
 
 #### errors
@@ -225,12 +225,13 @@ Gets track points for the specified track ID, tracker and time period.
 | name | description | type| format |
 | :------ | :------ | :----- | :----- |
 | tracker_id | Id of the tracker (aka "object_id"). Tracker must belong to authorized user and not be blocked. | int | 123456 |
-| from | From time in `yyyy-MM-dd HH:mm:ss` format (in user's timezone). | [date/time](../../../getting-started.md#data-types) | "2020-09-23 03:24:00" |
-| to | To time in `yyyy-MM-dd HH:mm:ss` format (in user's timezone). Specified date must be after "from" date. | [date/time](../../../getting-started.md#data-types) | "2020-09-23 06:24:00" |
+| from | From time in `yyyy-MM-dd HH:mm:ss` format (in user's timezone). | string date/time | "2020-09-23 03:24:00" |
+| to | To time in `yyyy-MM-dd HH:mm:ss` format (in user's timezone). Specified date must be after "from" date. | string date/time | "2020-09-23 06:24:00" |
 | track_id | Optional. If specified, only points belonging to the specified track will be returned. If not, any valid track points between "from" and "to" will be returned. | int | 234567 |
 | include_gsm_lbs | Optional, default=`true`. If `false` && track_id not specified, GSM LBS points will be filtered out. | boolean | true |
 | point_limit | Optional. If specified, the returned track will be simplified to contain this number of points. Min=2, Max=3000 | int | 3000 |
-| filter | Optional. If specified, the returned track will be filtered, applicable only for LBS tracks now. If `false` a response will contain parking points. | boolean | false |
+| filter | Optional. If specified, the returned track will be filtered, applicable only for LBS tracks now. | boolean | false |
+| split | Optional, default=`true`. If `false`, all tracks will be merged into single one. | boolean | true |
 
 #### examples
 
@@ -271,7 +272,7 @@ Gets track points for the specified track ID, tracker and time period.
 * `lng` - float.  Longitude.
 * `alt` - int. Altitude in meters. 
 * `satellites` - int. Number of satellites used in fix for this point.
-* `get_time` - [date/time](../../../getting-started.md#data-types). GPS timestamp of the point, in user's timezone.
+* `get_time` - string date/time. GPS timestamp of the point, in user's timezone.
 * `address` - string. Point address. Will be "" if no address recorded.
 * `heading` - int. Bearing in degrees (0..360).
 * `speed` - int. Speed in km/h.

--- a/docs/backend-api/resources/tracking/track/index.md
+++ b/docs/backend-api/resources/tracking/track/index.md
@@ -16,13 +16,13 @@ Downloads track points as KML/KMZ file for the specified track ID, tracker and t
 | name | description | type| format |
 | :------ | :------ | :----- | :----- |
 | tracker_id | Id of the tracker (aka "object_id"). Tracker must belong to authorized user and not be blocked. | int | `123456` |
-| from | From time in `yyyy-MM-dd HH:mm:ss` format (in user's timezone). | string date/time | `"2020-09-23 03:24:00"` |
-| to | To time in `yyyy-MM-dd HH:mm:ss` format (in user's timezone). Specified date must be after "from" date. | string date/time | `"2020-09-23 06:24:00"` |
+| from | From time in `yyyy-MM-dd HH:mm:ss` format (in user's timezone). | [date/time](../../../getting-started.md#data-types) | `"2020-09-23 03:24:00"` |
+| to | To time in `yyyy-MM-dd HH:mm:ss` format (in user's timezone). Specified date must be after "from" date. | [date/time](../../../getting-started.md#data-types) | `"2020-09-23 06:24:00"` |
 | track_ids | Optional. If specified, only points belonging to the specified tracks will be returned. If not, any valid track points between "from" and "to" will be returned. | array of int | `[123456, 234567]` | 
 | include_gsm_lbs | Optional. If `false` && track_ids not specified, GSM LBS points will be filtered out. Default=`true`. | boolean | `true` |
 | point_limit | Optional. If specified, the returned track will be simplified to contain this number of points. Min=2, Max=3000. If not specified, the server settings to decimates track will be used. | int | `300` |
 | filter | Optional. If specified, the returned track will be filtered, applicable only for LBS tracks now. | boolean | `true` |
-| format | File format, "kml" or "kmz", default is "kml". | string enum | `"kml"` |
+| format | File format, "kml" or "kmz", default is "kml". | [enum](../../../getting-started.md#data-types) | `"kml"` |
 | split | If `true`, split tracks by folders with start/end placemarks and track line. Default=`false`. | boolean | `false` |
 
 #### examples
@@ -63,8 +63,8 @@ Gets a list of track descriptions for the specified tracker and time period.
 | name | description | type| format |
 | :------ | :------ | :----- | :----- |
 | tracker_id | Id of the tracker (aka "object_id"). Tracker must belong to authorized user and not be blocked. | int | 123456 |
-| from | From time in `yyyy-MM-dd HH:mm:ss` format in user's timezone. | string date/time | "2020-09-23 03:24:00" |
-| to | To time in `yyyy-MM-dd HH:mm:ss` format in user's timezone. Specified date must be after "from" date. | string date/time | "2020-09-23 06:24:00" |
+| from | From time in `yyyy-MM-dd HH:mm:ss` format in user's timezone. | [date/time](../../../getting-started.md#data-types) | "2020-09-23 03:24:00" |
+| to | To time in `yyyy-MM-dd HH:mm:ss` format in user's timezone. Specified date must be after "from" date. | [date/time](../../../getting-started.md#data-types) | "2020-09-23 06:24:00" |
 | filter | Optional, default=`true`. If `true`, tracks which are too short (in terms of length and number of points) will be omitted from resulting list. | boolean | true |
 | split | Optional, default=`true`. If `false`, all tracks will be merged into single one.| boolean | true |
 | include_gsm_lbs | Optional, default=`true`. If `false`, GSM LBS tracks will be filtered out. | boolean | true |
@@ -117,10 +117,10 @@ where <track_info> is either <regular>, <single_report>, <merged> or <cluster>:
 ```
 
 * `id` - int. Track id.
-* `start_date` - string date/time. Track start date, in user's timezone e.g. "2011-06-18 03:39:44".
+* `start_date` - [date/time](../../../getting-started.md#data-types). Track start date, in user's timezone e.g. "2011-06-18 03:39:44".
 * `start_address` - string. Track start address.
 * `max_speed` - int. Maximum speed in km/h, e.g. 96.
-* `end_date` - string date/time. Track end date, in user's timezone e.g. "2011-06-18 05:18:36".
+* `end_date` - [date/time](../../../getting-started.md#data-types). Track end date, in user's timezone e.g. "2011-06-18 05:18:36".
 * `end_address` - string. Track end address.
 * `length` - float. Track length in kilometers, e.g. 85.5.
 * `points` - int. Total number of points in a track, e.g. 724.
@@ -128,7 +128,7 @@ where <track_info> is either <regular>, <single_report>, <merged> or <cluster>:
 * `event_count` - int. Number of events on this track. Field will be omitted if "count_events" is `false`.
 * `norm_fuel_consumed` - float. A consumed fuel on track, litres. Field will be omitted if no vehicle bound to tracker 
 or no normAvgFuelConsumption defined in a vehicle.
-* `type` - string enum. Used to distinguish this track type from the others. 
+* `type` - [enum](../../../getting-started.md#data-types). Used to distinguish this track type from the others. 
 * `gsm_lbs` - optional boolean. GSM LBS point flag.
 
 `single_report` object. Returned if device was creating reports in "interval" mode (e.g. M7 tracker in interval mode):
@@ -146,8 +146,8 @@ or no normAvgFuelConsumption defined in a vehicle.
 ```
 
 * `id` - int. Track id.
-* `type` - string enum. Used to distinguish this track type from the others. 
-* `start_date` - string date/time. Point creation date, in user's timezone e.g. "2011-06-18 03:39:44".
+* `type` - [enum](../../../getting-started.md#data-types). Used to distinguish this track type from the others. 
+* `start_date` - [date/time](../../../getting-started.md#data-types). Point creation date, in user's timezone e.g. "2011-06-18 03:39:44".
 * `start_address` - string. Point address.
 * `avg_speed` - int. Average speed in km/h, e.g. 70.
 * `gsm_lbs` - optional boolean. GSM LBS point flag.
@@ -173,10 +173,10 @@ or no normAvgFuelConsumption defined in a vehicle.
 }
 ```
 
-* `start_date` - string date/time. Track start date, in user's timezone e.g. "2011-06-18 03:39:44".
+* `start_date` - [date/time](../../../getting-started.md#data-types). Track start date, in user's timezone e.g. "2011-06-18 03:39:44".
 * `start_address` - string. Track start address.
 * `max_speed` - int. Maximum speed in km/h, e.g. 96.
-* `end_date` - string date/time. Track end date, in user's timezone e.g. "2011-06-18 05:18:36".
+* `end_date` - [date/time](../../../getting-started.md#data-types). Track end date, in user's timezone e.g. "2011-06-18 05:18:36".
 * `end_address` - string. Track end address.
 * `length` - float. Track length in kilometers, e.g. 85.5.
 * `points` - int. Total number of points in a track, e.g. 724.
@@ -184,7 +184,7 @@ or no normAvgFuelConsumption defined in a vehicle.
 * `event_count` - int. Number of events on this track. Field will be omitted if "count_events" is `false`.
 * `norm_fuel_consumed` - float. A consumed fuel on track, litres. Field will be omitted if no vehicle bound to tracker 
 or no normAvgFuelConsumption defined in a vehicle.
-* `type` - string enum. Used to distinguish this track type from the others. 
+* `type` - [enum](../../../getting-started.md#data-types). Used to distinguish this track type from the others. 
 * `gsm_lbs` - optional boolean. GSM LBS flag.
 
 `cluster` object. Only returned if "split" is set to `true`:
@@ -201,12 +201,12 @@ or no normAvgFuelConsumption defined in a vehicle.
 }
 ```
 
-* `start_date` - string date/time. Track start date, in user's timezone e.g. "2011-06-18 03:39:44".
+* `start_date` - [date/time](../../../getting-started.md#data-types). Track start date, in user's timezone e.g. "2011-06-18 03:39:44".
 * `start_address` - string. Track start address.
-* `end_date` - string date/time. Track end date, in user's timezone e.g. "2011-06-18 05:18:36".
+* `end_date` - [date/time](../../../getting-started.md#data-types). Track end date, in user's timezone e.g. "2011-06-18 05:18:36".
 * `precision` - optional int. Location precision, meters.
 * `points` - array of points in a cluster.
-* `type` - string enum. Used to distinguish this track type from the others. 
+* `type` - [enum](../../../getting-started.md#data-types). Used to distinguish this track type from the others. 
 * `gsm_lbs` - optional boolean. GSM LBS flag, true if cluster contains only GSM LBS points.
 
 #### errors
@@ -225,8 +225,8 @@ Gets track points for the specified track ID, tracker and time period.
 | name | description | type| format |
 | :------ | :------ | :----- | :----- |
 | tracker_id | Id of the tracker (aka "object_id"). Tracker must belong to authorized user and not be blocked. | int | 123456 |
-| from | From time in `yyyy-MM-dd HH:mm:ss` format (in user's timezone). | string date/time | "2020-09-23 03:24:00" |
-| to | To time in `yyyy-MM-dd HH:mm:ss` format (in user's timezone). Specified date must be after "from" date. | string date/time | "2020-09-23 06:24:00" |
+| from | From time in `yyyy-MM-dd HH:mm:ss` format (in user's timezone). | [date/time](../../../getting-started.md#data-types) | "2020-09-23 03:24:00" |
+| to | To time in `yyyy-MM-dd HH:mm:ss` format (in user's timezone). Specified date must be after "from" date. | [date/time](../../../getting-started.md#data-types) | "2020-09-23 06:24:00" |
 | track_id | Optional. If specified, only points belonging to the specified track will be returned. If not, any valid track points between "from" and "to" will be returned. | int | 234567 |
 | include_gsm_lbs | Optional, default=`true`. If `false` && track_id not specified, GSM LBS points will be filtered out. | boolean | true |
 | point_limit | Optional. If specified, the returned track will be simplified to contain this number of points. Min=2, Max=3000 | int | 3000 |
@@ -271,7 +271,7 @@ Gets track points for the specified track ID, tracker and time period.
 * `lng` - float.  Longitude.
 * `alt` - int. Altitude in meters. 
 * `satellites` - int. Number of satellites used in fix for this point.
-* `get_time` - string date/time. GPS timestamp of the point, in user's timezone.
+* `get_time` - [date/time](../../../getting-started.md#data-types). GPS timestamp of the point, in user's timezone.
 * `address` - string. Point address. Will be "" if no address recorded.
 * `heading` - int. Bearing in degrees (0..360).
 * `speed` - int. Speed in km/h.

--- a/docs/backend-api/resources/tracking/track/index.md
+++ b/docs/backend-api/resources/tracking/track/index.md
@@ -66,7 +66,7 @@ Gets a list of track descriptions for the specified tracker and time period.
 | from | From time in `yyyy-MM-dd HH:mm:ss` format in user's timezone. | string date/time | "2020-09-23 03:24:00" |
 | to | To time in `yyyy-MM-dd HH:mm:ss` format in user's timezone. Specified date must be after "from" date. | string date/time | "2020-09-23 06:24:00" |
 | filter | Optional, default=`true`. If `true`, tracks which are too short (in terms of length and number of points) will be omitted from resulting list. | boolean | true |
-| split | Optional, default=`true`. If `false`, all tracks will be merged into single one. | boolean | true |
+| split | Optional, default=`true`. If `false`, all tracks will be merged into single one, and response will contain parking points. | boolean | true |
 | include_gsm_lbs | Optional, default=`true`. If `false`, GSM LBS tracks will be filtered out. | boolean | true |
 | cluster_single_reports | Optional, default=`false`. If `true`, single point reports will be clustered by its coordinates. | boolean | false | 
 | count_events | Optional, default=`false`. If `true`, number of events occurred during each non-single point track will be returned. | true |
@@ -231,7 +231,7 @@ Gets track points for the specified track ID, tracker and time period.
 | include_gsm_lbs | Optional, default=`true`. If `false` && track_id not specified, GSM LBS points will be filtered out. | boolean | true |
 | point_limit | Optional. If specified, the returned track will be simplified to contain this number of points. Min=2, Max=3000 | int | 3000 |
 | filter | Optional. If specified, the returned track will be filtered, applicable only for LBS tracks now. | boolean | false |
-| split | Optional, default=`true`. If `false`, all tracks will be merged into single one. | boolean | true |
+| split | Optional, default=`true`. If `false`, all tracks will be merged into single one, and response will contain parking points. | boolean | true |
 
 #### examples
 

--- a/docs/backend-api/resources/tracking/track/index.md
+++ b/docs/backend-api/resources/tracking/track/index.md
@@ -18,7 +18,7 @@ Downloads track points as KML/KMZ file for the specified track ID, tracker and t
 | tracker_id | Id of the tracker (aka "object_id"). Tracker must belong to authorized user and not be blocked. | int | `123456` |
 | from | From time in `yyyy-MM-dd HH:mm:ss` format (in user's timezone). | [date/time](../../../getting-started.md#data-types) | `"2020-09-23 03:24:00"` |
 | to | To time in `yyyy-MM-dd HH:mm:ss` format (in user's timezone). Specified date must be after "from" date. | [date/time](../../../getting-started.md#data-types) | `"2020-09-23 06:24:00"` |
-| track_ids | Optional. If specified, only points belonging to the specified tracks will be returned. If not, any valid track points between "from" and "to" will be returned. | array of int | `[123456, 234567]` | 
+| track_ids | Optional. If specified, only points belonging to the specified tracks will be returned. If not, any valid track points between "from" and "to" will be returned. | int array | `[123456, 234567]` | 
 | include_gsm_lbs | Optional. If `false` && track_ids not specified, GSM LBS points will be filtered out. Default=`true`. | boolean | `true` |
 | point_limit | Optional. If specified, the returned track will be simplified to contain this number of points. Min=2, Max=3000. If not specified, the server settings to decimates track will be used. | int | `300` |
 | filter | Optional. If specified, the returned track will be filtered, applicable only for LBS tracks now. | boolean | `true` |

--- a/docs/backend-api/resources/tracking/track/index.md
+++ b/docs/backend-api/resources/tracking/track/index.md
@@ -66,7 +66,7 @@ Gets a list of track descriptions for the specified tracker and time period.
 | from | From time in `yyyy-MM-dd HH:mm:ss` format in user's timezone. | string date/time | "2020-09-23 03:24:00" |
 | to | To time in `yyyy-MM-dd HH:mm:ss` format in user's timezone. Specified date must be after "from" date. | string date/time | "2020-09-23 06:24:00" |
 | filter | Optional, default=`true`. If `true`, tracks which are too short (in terms of length and number of points) will be omitted from resulting list. | boolean | true |
-| split | Optional, default=`true`. If `false`, all tracks will be merged into single one, and response will contain parking points. | boolean | true |
+| split | Optional, default=`true`. If `false`, all tracks will be merged into single one.| boolean | true |
 | include_gsm_lbs | Optional, default=`true`. If `false`, GSM LBS tracks will be filtered out. | boolean | true |
 | cluster_single_reports | Optional, default=`false`. If `true`, single point reports will be clustered by its coordinates. | boolean | false | 
 | count_events | Optional, default=`false`. If `true`, number of events occurred during each non-single point track will be returned. | true |
@@ -230,8 +230,7 @@ Gets track points for the specified track ID, tracker and time period.
 | track_id | Optional. If specified, only points belonging to the specified track will be returned. If not, any valid track points between "from" and "to" will be returned. | int | 234567 |
 | include_gsm_lbs | Optional, default=`true`. If `false` && track_id not specified, GSM LBS points will be filtered out. | boolean | true |
 | point_limit | Optional. If specified, the returned track will be simplified to contain this number of points. Min=2, Max=3000 | int | 3000 |
-| filter | Optional. If specified, the returned track will be filtered, applicable only for LBS tracks now. | boolean | false |
-| split | Optional, default=`true`. If `false`, all tracks will be merged into single one, and response will contain parking points. | boolean | true |
+| filter | Optional. If specified, the returned track will be filtered, applicable only for LBS tracks now. If `false` a response will contain parking points. | boolean | false |
 
 #### examples
 

--- a/docs/backend-api/resources/tracking/tracker/chat.md
+++ b/docs/backend-api/resources/tracking/tracker/chat.md
@@ -81,7 +81,7 @@ Marks all incoming chat messages as read for all or for given user trackers.
 
 | name | description | type | format |
 | :------ | :------ | :----- | :----- |
-| trackers | Optional array of Ids of the tracker (aka "object_id"). Tracker must belong to authorized user and not be blocked. | array of int | `[999199, 999919]` |
+| trackers | Optional array of Ids of the tracker (aka "object_id"). Tracker must belong to authorized user and not be blocked. | int array | `[999199, 999919]` |
 
 #### examples
 
@@ -118,7 +118,7 @@ Marks incoming chat message as read by `message_id` or array of `message_ids`.
 | name | description | type | format |
 | :------ | :------ | :----- | :----- |
 | message_id | Id of incoming message. | int | 123 |
-| message_ids | Ids of incoming messages. | array of int | `[123,213]` |
+| message_ids | Ids of incoming messages. | int array | `[123,213]` |
 
 Use only one parameter.
 
@@ -196,7 +196,7 @@ Sends chat message to specified trackers.
 
 | name | description | type | format |
 | :------ | :------ | :----- | :----- |
-| trackers | Array of Ids of the tracker (aka "object_id"). Tracker must belong to authorized user and not be blocked. Max size - 300. | array of int | `[999199, 999919]` |
+| trackers | Array of Ids of the tracker (aka "object_id"). Tracker must belong to authorized user and not be blocked. Max size - 300. | int array | `[999199, 999919]` |
 | message | Message text, not null, max size - 20000. | string | "Hello World" |
 
 #### examples
@@ -235,7 +235,7 @@ Gets date-times of last messages in chat of trackers.
 
 | name | description | type | format |
 | :------ | :------ | :----- | :----- |
-| trackers | Array of Ids of the tracker (aka "object_id"). Tracker must belong to authorized user and not be blocked. Max size - 300. | array of int | [999199, 999919] |
+| trackers | Array of Ids of the tracker (aka "object_id"). Tracker must belong to authorized user and not be blocked. Max size - 300. | int array | `[999199, 999919]` |
 
 #### examples
 

--- a/docs/backend-api/resources/tracking/tracker/counter/value.md
+++ b/docs/backend-api/resources/tracking/tracker/counter/value.md
@@ -59,7 +59,7 @@ Get values for counters of passed `type` and `trackers`.
 
 | name | description | type| format|
 | :------ | :------ | :----- | :------ |
-| trackers | List of the tracker's Ids belonging to authorized user. | array of int | `[123456, 234567]` |
+| trackers | List of the tracker's Ids belonging to authorized user. | int array | `[123456, 234567]` |
 | type | Counter type. One of `["odometer", "fuel_consumed", "engine_hours"]`. | [enum](../../../../getting-started.md#data-types) | "odometer" |
 
 #### examples

--- a/docs/backend-api/resources/tracking/tracker/group.md
+++ b/docs/backend-api/resources/tracking/tracker/group.md
@@ -35,7 +35,7 @@ Assigns multiple trackers to the specified group.
 | name | description | type | format |
 | :------ | :------ | :----- | :----- |
 | id | Group id, or 0 if trackers should be removed from any group. | int | 167 |
-| trackers | Array of Ids of the tracker (aka "object_id"). Tracker must belong to authorized user and not be blocked. | array of int | `[999199, 999919]` |
+| trackers | Array of Ids of the tracker (aka "object_id"). Tracker must belong to authorized user and not be blocked. | int array | `[999199, 999919]` |
 
 #### examples
 

--- a/docs/backend-api/resources/tracking/tracker/index.md
+++ b/docs/backend-api/resources/tracking/tracker/index.md
@@ -792,7 +792,7 @@ Gets current states (gps, gsm, outputs, etc.) for several trackers.
 
 | name | description | type | format |
 | :------ | :------ | :----- | :----- |
-| trackers | Id of trackers (aka "object_id"). Trackers must belong to authorized user and not be blocked. | array of int | `[999119, 999199]` |
+| trackers | Id of trackers (aka "object_id"). Trackers must belong to authorized user and not be blocked. | int array | `[999119, 999199]` |
 | list_blocked | Optional. If `true` call returns list of blocked tracker IDs instead of error 208. Default is `false`. | boolean | true/false |
 | allow_not_exist | Optional. If `true` call returns list of nonexistent tracker IDs instead of error 217 or 201. Default is `false`. | boolean | true/false |
 
@@ -877,7 +877,7 @@ Gets all integrated tracker models (from "models" table).
 | name | description | type | format |
 | :------ | :------ | :----- | :----- |
 | compact_view | Optional. `true` to compact view. Default is `false`. | boolean | true/false |
-| codes | Optional. Array of model codes. If passed only given models will be returned. | array of string | `[model_1, model_2, ...]` |
+| codes | Optional. Array of model codes. If passed only given models will be returned. | string array | `[model_1, model_2, ...]` |
 
 #### examples
 
@@ -1007,7 +1007,7 @@ Gets user's trackers with optional filtering by labels.
 
 | name | description | type | format |
 | :------ | :------ | :----- | :----- |
-| labels | Optional. List of tracker label filters. If specified, only trackers that labels contains any of the given filter will be returned. | array of string | `["aa", "b"]` |
+| labels | Optional. List of tracker label filters. If specified, only trackers that labels contains any of the given filter will be returned. | string array | `["aa", "b"]` |
 
 Constraints for labels:
 

--- a/docs/backend-api/resources/tracking/tracker/rules/rule.md
+++ b/docs/backend-api/resources/tracking/tracker/rules/rule.md
@@ -48,16 +48,16 @@ A rule element consists of following fields:
 * `id` - int. An id of a rule.
 * `name` - string. Name of a rule.
 * `description` - string. Rule's description.
-* `zone_ids` - array of int. List of geofence ids.
-* `trackers` - array of int. List of bound tracker ids.
+* `zone_ids` - int array. List of geofence ids.
+* `trackers` - int array. List of bound tracker ids.
 * `type` - enum. One of pre-defined types of rules. See [rule types](./rule_types.md).
 * `primary_text` - string. Primary text of rule notification.
 * `secondary_text` - string. Secondary text of rule notification.
 * `param` - int. A common parameter. See [rule types](./rule_types.md).
 * `alerts` - object with destinations for notifications. 
-    * `sms_phones` - array of string. Phones for SMS notifications.
-    * `phones` - array of string. Phones for voice calls.
-    * `emails` - array of string. Emails for notifications.
+    * `sms_phones` - string array. Phones for SMS notifications.
+    * `phones` - string array. Phones for voice calls.
+    * `emails` - string array. Emails for notifications.
     * `push_enabled` - boolean. If `true` push notifications available.
     * `emergency` - boolean. If `true` notifications will be marked as emergency with color and sound.
 * `suspended` - boolean. `true` if the rule suspended.
@@ -112,7 +112,7 @@ Binds rule with `rule_id` to trackers list.
 | name | description | type |
 | :------ | :------ | :----- |
 | rule_id | Id of a rule. | int |
-| trackers | Ids of trackers. Trackers which do not exist, owned by other user or deleted ignored without errors. | array of int |
+| trackers | Ids of trackers. Trackers which do not exist, owned by other user or deleted ignored without errors. | int array |
 
 #### example
 
@@ -146,8 +146,8 @@ Creates rule and scheduled intervals.
 | :------ | :------ | :----- |
 | name | The name of created rule. | string |
 | description | Rule's description. | string |
-| zone_ids | List of zones to bind where the rule will work. Leave it empty if rule should work everywhere. Parameter `zone_ids` is not allowed for rule `offline` and required for `route` and `inoutzone` rule types.s. | array of int |
-| trackers | List of tracker ids belong to user for which the rule will work. | array of int |
+| zone_ids | List of zones to bind where the rule will work. Leave it empty if rule should work everywhere. Parameter `zone_ids` is not allowed for rule `offline` and required for `route` and `inoutzone` rule types.s. | int array |
+| trackers | List of tracker ids belong to user for which the rule will work. | int array |
 | type | One of pre-defined types of rules. See [rule types](./rule_types.md). | [enum](../../../../getting-started.md#data-types) |
 | primary_text | Primary text of rule notification when condition is true. | string |
 | secondary_text | Secondary text of rule notification when condition is false. | string |
@@ -328,8 +328,8 @@ Updates rule and scheduled intervals.
 | id | Id of a rule. You can get ids using the [rule/list](#list) call. | int |
 | name | The name of created rule. | string |
 | description | Rule's description. | string |
-| zone_ids | List of zones to bind where the rule will work. Leave it empty if rule should work everywhere. Parameter `zone_ids` is not allowed for rule `offline` and required for `route` and `inoutzone` rule types. | array of int |
-| trackers | List of tracker ids belong to user for which the rule will work. | array of int |
+| zone_ids | List of zones to bind where the rule will work. Leave it empty if rule should work everywhere. Parameter `zone_ids` is not allowed for rule `offline` and required for `route` and `inoutzone` rule types. | int array |
+| trackers | List of tracker ids belong to user for which the rule will work. | int array |
 | type | One of pre-defined types of rules. See [rule types](./rule_types.md). | [enum](../../../../getting-started.md#data-types) |
 | primary_text | Primary text of rule notification when condition is true. | string |
 | secondary_text | Secondary text of rule notification when condition is false. | string |

--- a/docs/backend-api/resources/tracking/tracker/rules/rule.md
+++ b/docs/backend-api/resources/tracking/tracker/rules/rule.md
@@ -142,7 +142,20 @@ Creates rule and scheduled intervals.
 
 #### parameters
 
-* **rule** - [JSON object](#rule).
+| name | description | type |
+| :------ | :------ | :----- |
+| name | The name of created rule. | string |
+| description | Rule's description. | string |
+| zone_ids | List of zones to bind where the rule will work. Leave it empty if rule should work everywhere. Parameter `zone_ids` is not allowed for rule `offline` and required for `route` and `inoutzone` rule types.s. | array of int |
+| trackers | List of tracker ids belong to user for which the rule will work. | array of int |
+| type | One of pre-defined types of rules. See [rule types](./rule_types.md). | string enum |
+| primary_text | Primary text of rule notification when condition is true. | string |
+| secondary_text | Secondary text of rule notification when condition is false. | string |
+| param | A common parameter that responsible for integer conditions. See [rule types](./rule_types.md). | int |
+| alerts | An object with destinations for notifications. Described [above](#rule-object). | JSON object |
+| suspended | Starts and stops the rule. `true` if the rule suspended. | boolean |
+| schedule | An optional object. Configures the time - when the rule works. Described [above](#rule-object). | JSON object |
+| extended_params | An optional object. Specified for concrete rule type. See [rule types](./rule_types.md). | JSON object |
 
 #### example
 
@@ -310,7 +323,21 @@ Updates rule and scheduled intervals.
 
 #### parameters
 
-* **rule** - [JSON object](#rule).
+| name | description | type |
+| :------ | :------ | :----- |
+| id | Id of a rule. You can get ids using the [rule/list](#list) call. | int |
+| name | The name of created rule. | string |
+| description | Rule's description. | string |
+| zone_ids | List of zones to bind where the rule will work. Leave it empty if rule should work everywhere. Parameter `zone_ids` is not allowed for rule `offline` and required for `route` and `inoutzone` rule types. | array of int |
+| trackers | List of tracker ids belong to user for which the rule will work. | array of int |
+| type | One of pre-defined types of rules. See [rule types](./rule_types.md). | string enum |
+| primary_text | Primary text of rule notification when condition is true. | string |
+| secondary_text | Secondary text of rule notification when condition is false. | string |
+| param | A common parameter that responsible for integer conditions. See [rule types](./rule_types.md). | int |
+| alerts | An object with destinations for notifications. Described [above](#rule-object). | JSON object |
+| suspended | Starts and stops the rule. `true` if the rule suspended. | boolean |
+| schedule | An optional object. Configures the time - when the rule works. Described [above](#rule-object). | JSON object |
+| extended_params | An optional object. Specified for concrete rule type. See [rule types](./rule_types.md). | JSON object |
 
 #### example
 

--- a/docs/backend-api/resources/tracking/tracker/rules/rule.md
+++ b/docs/backend-api/resources/tracking/tracker/rules/rule.md
@@ -11,48 +11,46 @@ A rule element consists of following fields:
 
 ```json
 {
-  "id": 668054,
-  "name": "Lock is opened/closed",
-  "type": "locking_unlocking",
-  "description": "This rule was created automatically",
-  "zone_ids": [ 18928 ],
-  "trackers": [ 10029750, 10030168, 10031971 ],
-  "primary_text": "Lock is opened",
-  "secondary_text": "Lock is closed",
-  "param": 0,
-  "alerts": {
-    "sms_phones": [],
-    "phones": [],
-    "emails": [],
-    "push_enabled": true
-  },
-  "suspended": false,
-  "auto_created": true,
-  "schedule": [{
-    "type": "weekly",
-    "from": {
-      "weekday": 1,
-      "time": "00:00:00"
+    "id": 1,
+    "name": "rule",
+    "description": "description",
+    "zone_ids": [12, 15],
+    "trackers": [123456, 234567],
+    "type": "alarmcontrol",
+    "primary_text": "ON",
+    "secondary_text": "OFF",
+    "param": 1,
+    "alerts": {
+      "sms_phones": ["98829991"],
+      "phones": ["98829991"],
+      "emails": ["example@test.com"],
+      "push_enabled": true,
+      "emergency": false
     },
-    "to": {
-      "weekday": 7,
-      "time": "23:59:59"
+    "suspended": false,
+    "schedule": [{
+      "type":"weekly",
+      "from":{"weekday":1,"time":"00:00:00"},
+      "to":{"weekday":7,"time":"23:59:59"}],
+    "extended_params": {
+      "alarmcontrol": {
+      "enabled": true,
+      "sms": false,
+      "call": false,
+      "email": true,
+      "push": true,
+      "always_notify": false
     },
-    "interval_id": 48732
-  }],
-  "extended_params": {
-    "emergency": false,
-    "zone_limit_inverted": false
-  }
+    "auto_created": true
 }
 ```
 
 * `id` - int. An id of a rule.
 * `name` - string. Name of a rule.
-* `type` - enum. One of pre-defined types of rules. See [rule types](./rule_types.md).
 * `description` - string. Rule's description.
 * `zone_ids` - array of int. List of geofence ids.
 * `trackers` - array of int. List of bound tracker ids.
+* `type` - enum. One of pre-defined types of rules. See [rule types](./rule_types.md).
 * `primary_text` - string. Primary text of rule notification.
 * `secondary_text` - string. Secondary text of rule notification.
 * `param` - int. A common parameter. See [rule types](./rule_types.md).
@@ -63,9 +61,9 @@ A rule element consists of following fields:
     * `push_enabled` - boolean. If `true` push notifications available.
     * `emergency` - boolean. If `true` notifications will be marked as emergency with color and sound.
 * `suspended` - boolean. `true` if the rule suspended.
-* `auto_created` - optional, boolean. `true` means that the rule created automatically.
 * `shedule` - optional object. The rule will work in specified period. 
 * `extended_params` - optional. An object specified for concrete rule type. See [rule types](./rule_types.md).
+* `auto_created` - optional, boolean. `true` means that the rule created automatically.
 
 * **schedule_interval** is one of:
 
@@ -75,12 +73,12 @@ A rule element consists of following fields:
     {
       "type": "weekly",
       "from": {
-        "weekday": 1,
-        "time": "00:00:00"
+        "weekday":1,
+        "time":"00:00:00"
       },
       "to": {
-        "weekday": 7,
-        "time": "23:59:59"
+        "weekday":7,
+        "time":"23:59:59"
       },
       "interval_id": 1
     }
@@ -144,20 +142,7 @@ Creates rule and scheduled intervals.
 
 #### parameters
 
-| name | description | type |
-| :------ | :------ | :----- |
-| name | The name of created rule. | string |
-| description | Rule's description. | string |
-| zone_ids | List of zones to bind where the rule will work. Leave it empty if rule should work everywhere. Parameter `zone_ids` is not allowed for rule `offline` and required for `route` and `inoutzone` rule types.s. | array of int |
-| trackers | List of tracker ids belong to user for which the rule will work. | array of int |
-| type | One of pre-defined types of rules. See [rule types](./rule_types.md). | [enum](../../../../getting-started.md#data-types) |
-| primary_text | Primary text of rule notification when condition is true. | string |
-| secondary_text | Secondary text of rule notification when condition is false. | string |
-| param | A common parameter that responsible for integer conditions. See [rule types](./rule_types.md). | int |
-| alerts | An object with destinations for notifications. Described [above](#rule-object). | JSON object |
-| suspended | Starts and stops the rule. `true` if the rule suspended. | boolean |
-| schedule | An optional object. Configures the time - when the rule works. Described [above](#rule-object). | JSON object |
-| extended_params | An optional object. Specified for concrete rule type. See [rule types](./rule_types.md). | JSON object |
+* **rule** - [JSON object](#rule).
 
 #### example
 
@@ -248,35 +233,36 @@ List tracker rules bound to tracker with an id=`tracker_id` or all users' tracke
 {
    "success": true,
    "list": [{
-     "id": 667281,
-     "name": "Case intrusion",
-     "type": "case_intrusion",
-     "description": "This rule was created automatically",
-     "zone_id": 0,
-     "trackers": [10029448, 10030168],
-     "primary_text": "Case is opened",
-     "secondary_text": "Case is closed",
-     "param": 0,
-     "alerts": {
-       "sms_phones": [],
-       "phones": [],
-       "emails": [],
-       "push_enabled": true
-     },
-     "suspended": false,
-     "auto_created": true,
-     "schedule": [{
-       "type": "weekly",
-       "from": {
-         "weekday": 1,
-         "time": "00:00:00"
-       },
-       "to": {
-         "weekday": 7,
-         "time": "23:59:59"
-       },
-       "interval_id": 46892
-     }]
+        "id": 1,
+        "name": "rule",
+        "description": "description",
+        "zone_ids": [12, 15],
+        "trackers": [123456, 234567],
+        "type": "alarmcontrol",
+        "primary_text": "ON",
+        "secondary_text": "OFF",
+        "param": 1,
+        "alerts": {
+          "sms_phones": ["98829991"],
+          "phones": ["98829991"],
+          "emails": ["example@test.com"],
+          "push_enabled": true
+        },
+        "suspended": false,
+        "schedule": [{
+          "type":"weekly",
+          "from":{"weekday":1,"time":"00:00:00"},
+          "to":{"weekday":7,"time":"23:59:59"}],
+        "extended_params": {
+          "alarmcontrol": {
+          "enabled": true,
+          "sms": false,
+          "call": false,
+          "email": true,
+          "push": true,
+          "always_notify": false
+        },
+        "auto_created": true
    }]
 }
 ```
@@ -324,21 +310,7 @@ Updates rule and scheduled intervals.
 
 #### parameters
 
-| name | description | type |
-| :------ | :------ | :----- |
-| id | Id of a rule. You can get ids using the [rule/list](#list) call. | int |
-| name | The name of created rule. | string |
-| description | Rule's description. | string |
-| zone_ids | List of zones to bind where the rule will work. Leave it empty if rule should work everywhere. Parameter `zone_ids` is not allowed for rule `offline` and required for `route` and `inoutzone` rule types. | array of int |
-| trackers | List of tracker ids belong to user for which the rule will work. | array of int |
-| type | One of pre-defined types of rules. See [rule types](./rule_types.md). | [enum](../../../../getting-started.md#data-types) |
-| primary_text | Primary text of rule notification when condition is true. | string |
-| secondary_text | Secondary text of rule notification when condition is false. | string |
-| param | A common parameter that responsible for integer conditions. See [rule types](./rule_types.md). | int |
-| alerts | An object with destinations for notifications. Described [above](#rule-object). | JSON object |
-| suspended | Starts and stops the rule. `true` if the rule suspended. | boolean |
-| schedule | An optional object. Configures the time - when the rule works. Described [above](#rule-object). | JSON object |
-| extended_params | An optional object. Specified for concrete rule type. See [rule types](./rule_types.md). | JSON object |
+* **rule** - [JSON object](#rule).
 
 #### example
 

--- a/docs/backend-api/resources/tracking/tracker/rules/rule.md
+++ b/docs/backend-api/resources/tracking/tracker/rules/rule.md
@@ -148,7 +148,7 @@ Creates rule and scheduled intervals.
 | description | Rule's description. | string |
 | zone_ids | List of zones to bind where the rule will work. Leave it empty if rule should work everywhere. Parameter `zone_ids` is not allowed for rule `offline` and required for `route` and `inoutzone` rule types.s. | array of int |
 | trackers | List of tracker ids belong to user for which the rule will work. | array of int |
-| type | One of pre-defined types of rules. See [rule types](./rule_types.md). | string enum |
+| type | One of pre-defined types of rules. See [rule types](./rule_types.md). | [enum](../../../../getting-started.md#data-types) |
 | primary_text | Primary text of rule notification when condition is true. | string |
 | secondary_text | Secondary text of rule notification when condition is false. | string |
 | param | A common parameter that responsible for integer conditions. See [rule types](./rule_types.md). | int |
@@ -330,7 +330,7 @@ Updates rule and scheduled intervals.
 | description | Rule's description. | string |
 | zone_ids | List of zones to bind where the rule will work. Leave it empty if rule should work everywhere. Parameter `zone_ids` is not allowed for rule `offline` and required for `route` and `inoutzone` rule types. | array of int |
 | trackers | List of tracker ids belong to user for which the rule will work. | array of int |
-| type | One of pre-defined types of rules. See [rule types](./rule_types.md). | string enum |
+| type | One of pre-defined types of rules. See [rule types](./rule_types.md). | [enum](../../../../getting-started.md#data-types) |
 | primary_text | Primary text of rule notification when condition is true. | string |
 | secondary_text | Secondary text of rule notification when condition is false. | string |
 | param | A common parameter that responsible for integer conditions. See [rule types](./rule_types.md). | int |

--- a/docs/backend-api/resources/tracking/tracker/rules/rule_types.md
+++ b/docs/backend-api/resources/tracking/tracker/rules/rule_types.md
@@ -18,10 +18,10 @@ Common parameters exist in all rule types.
 | alerts | Alerts object with destinations for notifications. Described in [rule_object](./rule.md#rule-object). | JSON object |
 | suspended | `true` if the rule suspended. | boolean |
 | name | Name of a rule. | string |
-| trackers | List of bound tracker ids. | array of int |
+| trackers | List of bound tracker ids. | int array |
 | extended_params | Extended parameters for the rule. Described below. | JSON object |
 | schedule | The rule will work in specified period. Described in [rule_object](./rule.md#rule-object). | JSON object |
-| zone_ids | List of bound zones. | array of int |
+| zone_ids | List of bound zones. | int array |
 
 #### Common extended parameters
 
@@ -101,7 +101,7 @@ A rule that triggers on status changing.
 
 | name | description | type |
 | ------ | ------------- | ------ |
-| status_ids | List of tracked status ids. | array of int |
+| status_ids | List of tracked status ids. | int array |
 
 ### Task performance
 
@@ -117,7 +117,7 @@ A rule that triggers on task status changes.
 
 | name | description | type |
 | ------ | ------------- | ------ |
-| statuses | List of tracked statuses. Possible statuses are "arrived", "done","delayed", "failed". | array of string |
+| statuses | List of tracked statuses. Possible statuses are "arrived", "done","delayed", "failed". | string array |
 | on_form_submission | If `true` form submission will track. | boolean |
 | on_repeated_form_submission | If `true` form resubmission will track. | boolean |
 

--- a/docs/backend-api/resources/tracking/tracker/sensor/index.md
+++ b/docs/backend-api/resources/tracking/tracker/sensor/index.md
@@ -45,9 +45,9 @@ Metering sensor
 * `units` - string.
 * `units_type` - [enum](../../../../getting-started.md#data-types). Units type for a sensor.
 * `parameters` - optional object with additional parameters.
-    * `parent_ids` - optional array of parent_ids for composite sensor.
+    * `parent_ids` - optional parent_ids array for composite sensor.
     * `volume` - double. Optional. Volume for composite sensor.
-    * `parent_ids` - optional. Array of int. Array of `parent_ids` for composite sensor.
+    * `parent_ids` - optional int array. Array of `parent_ids` for composite sensor.
     * `volume` - optional. Double. Volume for composite sensor.
     * `min` - optional. Double. Min acceptable raw value for a sensor.
     * `max` - optional. Double. Max acceptable raw value for a sensor.
@@ -80,7 +80,7 @@ There exist a similar method for working with a single tracker - [list](#list).
 #### parameters
 | Name | Description | Type |
 | --- | --- | --- |
-| trackers | Set of tracker identificators. Each of the relevant trackers must be accessible to the authorized user and not be blocked. Number of trackers (length of array) is limited to a maximum of 500 (this number may be changed in future). | array of ints |
+| trackers | Set of tracker identificators. Each of the relevant trackers must be accessible to the authorized user and not be blocked. Number of trackers (length of array) is limited to a maximum of 500 (this number may be changed in future). | int array |
 
 #### response
 Contains a map, where keys are IDs from **trackers** parameter and values are lists of [sensor](#sensor) objects.

--- a/docs/backend-api/resources/tracking/tracker/settings/special/index.md
+++ b/docs/backend-api/resources/tracking/tracker/settings/special/index.md
@@ -295,7 +295,7 @@ If parameter type omitted:
 }
 ```
 
-* `emails` - array of strings. Valid emails. Maximum size 5.
+* `emails` - string array. Valid emails. Maximum size 5.
 
 **digital_password**
 

--- a/docs/backend-api/resources/tracking/tracker/trusted_number.md
+++ b/docs/backend-api/resources/tracking/tracker/trusted_number.md
@@ -59,7 +59,7 @@ Replaces the list of trusted numbers for a specified tracker with the new one.
 | name | description | type | format |
 | :------ | :------ | :----- | :----- |
 | tracker_id | Id of the tracker (aka "object_id"). Tracker must belong to authorized user and not be blocked. | int | 999199 |
-| list | Array of phone numbers (10-15 digits) represented as strings. | array of string | `["496156680001", "496156680000"]` |
+| list | Array of phone numbers (10-15 digits) represented as strings. | string array | `["496156680001", "496156680000"]` |
 
 #### examples
 

--- a/docs/backend-api/resources/tracking/zone/index.md
+++ b/docs/backend-api/resources/tracking/zone/index.md
@@ -39,7 +39,7 @@ represented by big arrays of data.
 * `color` - string. Zone color in 3-byte RGB hex format.
 * `radius` - int. Circle radius in meters.
 * `center` - location object. Location of circle center.
-* `tags` - Array of int. Array of tag IDs.
+* `tags` - int array. Array of tag IDs.
 
 #### polygon:
 
@@ -58,7 +58,7 @@ represented by big arrays of data.
 * `label` - string. Zone label.
 * `address` - string. Zone address.
 * `color` - string. Zone color in 3-byte RGB hex format.
-* `tags` - Array of int. Array of tag IDs.
+* `tags` - int array. Array of tag IDs.
 
 #### sausage:
 
@@ -81,7 +81,7 @@ Represents all points within certain distance to the specified polyline.
 * `address` - string. Zone address.
 * `color` - string. Zone color in 3-byte RGB hex format.
 * `radius` - int. Polyline radius in meters.
-* `tags` - Array of int. Array of tag IDs.                 
+* `tags` - int array. Array of tag IDs.                 
 
 ## API actions
 
@@ -147,7 +147,7 @@ For `batch` parameter:
 * `color` - string. Zone color in 3-byte RGB hex format.
 * `radius` - int. Circle radius in meters.
 * `center` - location object. Location of circle center.
-* `tags` - Array of int. Array of tag IDs.
+* `tags` - int array. Array of tag IDs.
 * `limit_exceeded` - boolean, true if given batch constrained by limit 
 
 #### response with errors object
@@ -237,7 +237,7 @@ Deletes user's zone by `zone_id` or array of `zone_ids`.
 | name | description | type| format |
 | :------ | :------ | :----- | :----- |
 | zone_id | Id of a zone. | int | 1234567 |
-| zone_ids | Array of zone ids. | array of int | `[1234567, 2345678]` |
+| zone_ids | Array of zone ids. | int array | `[1234567, 2345678]` |
 
 * Use only one parameter `zone_id` or `zone_ids`.
 
@@ -286,7 +286,7 @@ Deletes user's zone by `zone_id` or array of `zone_ids`.
 }
 ```
 
-* `ids` - array of int. List IDs of the rules which uses the specified zone.
+* `ids` - int array. List IDs of the rules which uses the specified zone.
 
 ### list
 

--- a/docs/backend-api/websocket/events.md
+++ b/docs/backend-api/websocket/events.md
@@ -8,8 +8,8 @@ description: Information about WebSocket events with conditions for obtaining an
 The server sends an `event message` through the WebSocket channel when an event occurs and client has subscription on this. 
 All event messages contain the next fields:
 
-* `type` - string enum. "event".
-* `event` - string enum. Can be "state", "lifecycle", or "logout".
+* `type` - [enum](../getting-started.md#data-types). "event".
+* `event` - [enum](../getting-started.md#data-types). Can be "state", "lifecycle", or "logout".
 * `data` - optional object. Specific event payload. 
 
 ## State event

--- a/docs/backend-api/websocket/events.md
+++ b/docs/backend-api/websocket/events.md
@@ -8,8 +8,8 @@ description: Information about WebSocket events with conditions for obtaining an
 The server sends an `event message` through the WebSocket channel when an event occurs and client has subscription on this. 
 All event messages contain the next fields:
 
-* `type` - [enum](../getting-started.md#data-types). "event".
-* `event` - [enum](../getting-started.md#data-types). Can be "state", "lifecycle", or "logout".
+* `type` - string enum. "event".
+* `event` - string enum. Can be "state", "lifecycle", or "logout".
 * `data` - optional object. Specific event payload. 
 
 ## State event

--- a/docs/backend-api/websocket/subscription.md
+++ b/docs/backend-api/websocket/subscription.md
@@ -18,8 +18,8 @@ Request parameters:
 
 * `action` (text: "subscribe").
 * `hash` - required, string, length=32. Session hash code obtained by [user/auth](../resources/commons/user/index.md#auth) action.
-* `trackers` - required, array of int, can't be null. List of tracker ids for the events that require a subscription.
-* `events` - required, array of string enum, can't be null. List of events to subscribe. Event can be one of: `state`.
+* `trackers` - required, array of int, without nulls. List of tracker ids for the events that require a subscription.
+* `events` - required, [enum](../getting-started.md#data-types) array, without nulls. List of events to subscribe. Event can be one of: `state`.
 
 Request sample:
 
@@ -38,8 +38,8 @@ Response parameters:
 
 * `type` - required, text: _"response"_.
 * `action` - required, text: _"subscription/subscribe"_.
-* `events` - required, array of string enum, can't be null. List of the subscribed events. Event can be `state`.
-* `data` - required, map <string, object>, can't be null. Map with events subscription result. One key per subscribed event.
+* `events` - required, array of [enum](../getting-started.md#data-types), without nulls. List of the subscribed events. Event can be `state`.
+* `data` - required, map <string, object>. Map with events subscription result. One key per subscribed event.
   * `state` - presented if the "state" subscription requested, map <string, enum> - the current status of requested trackers.
 
 Keys is a tracker ids, values - one of the item:
@@ -93,7 +93,7 @@ Request parameters:
 * `action` - text: _"unsubscribe"_.
 * `hash` - required, string, length=32. Session hash code gotten by [user/auth](../resources/commons/user/index.md#auth) action.
 * `trackers` - required, array of int, without nulls. List of tracker ids for events that require an unsubscription.
-* `events` - required, array of string enum, without nulls. List of events to unsubscribe. Event can be `state`.
+* `events` - required, [enum](../getting-started.md#data-types) array, without nulls. List of events to unsubscribe. Event can be `state`.
 
 Request sample:
 
@@ -112,7 +112,7 @@ Response parameters:
 
 * `type` - required, text: _"response"_.
 * `action` - required, text: _"subscription/unsubscribe"_.
-* `events` - required, array of string enum, without nulls. List of unsubscribed events. Event can be `state`.
+* `events` - required, [enum](../getting-started.md#data-types) array, without nulls. List of unsubscribed events. Event can be `state`.
 * `data` - required, array of int, without nulls. List of tracker ids from request.
 
 Response sample:

--- a/docs/backend-api/websocket/subscription.md
+++ b/docs/backend-api/websocket/subscription.md
@@ -18,8 +18,8 @@ Request parameters:
 
 * `action` (text: "subscribe").
 * `hash` - required, string, length=32. Session hash code obtained by [user/auth](../resources/commons/user/index.md#auth) action.
-* `trackers` - required, array of int, without nulls. List of tracker ids for the events that require a subscription.
-* `events` - required, [enum](../getting-started.md#data-types) array, without nulls. List of events to subscribe. Event can be one of: `state`.
+* `trackers` - required, array of int, can't be null. List of tracker ids for the events that require a subscription.
+* `events` - required, array of string enum, can't be null. List of events to subscribe. Event can be one of: `state`.
 
 Request sample:
 
@@ -38,8 +38,8 @@ Response parameters:
 
 * `type` - required, text: _"response"_.
 * `action` - required, text: _"subscription/subscribe"_.
-* `events` - required, array of [enum](../getting-started.md#data-types), without nulls. List of the subscribed events. Event can be `state`.
-* `data` - required, map <string, object>. Map with events subscription result. One key per subscribed event.
+* `events` - required, array of string enum, can't be null. List of the subscribed events. Event can be `state`.
+* `data` - required, map <string, object>, can't be null. Map with events subscription result. One key per subscribed event.
   * `state` - presented if the "state" subscription requested, map <string, enum> - the current status of requested trackers.
 
 Keys is a tracker ids, values - one of the item:
@@ -93,7 +93,7 @@ Request parameters:
 * `action` - text: _"unsubscribe"_.
 * `hash` - required, string, length=32. Session hash code gotten by [user/auth](../resources/commons/user/index.md#auth) action.
 * `trackers` - required, array of int, without nulls. List of tracker ids for events that require an unsubscription.
-* `events` - required, [enum](../getting-started.md#data-types) array, without nulls. List of events to unsubscribe. Event can be `state`.
+* `events` - required, array of string enum, without nulls. List of events to unsubscribe. Event can be `state`.
 
 Request sample:
 
@@ -112,7 +112,7 @@ Response parameters:
 
 * `type` - required, text: _"response"_.
 * `action` - required, text: _"subscription/unsubscribe"_.
-* `events` - required, [enum](../getting-started.md#data-types) array, without nulls. List of unsubscribed events. Event can be `state`.
+* `events` - required, array of string enum, without nulls. List of unsubscribed events. Event can be `state`.
 * `data` - required, array of int, without nulls. List of tracker ids from request.
 
 Response sample:

--- a/docs/backend-api/websocket/subscription.md
+++ b/docs/backend-api/websocket/subscription.md
@@ -18,7 +18,7 @@ Request parameters:
 
 * `action` (text: "subscribe").
 * `hash` - required, string, length=32. Session hash code obtained by [user/auth](../resources/commons/user/index.md#auth) action.
-* `trackers` - required, array of int, without nulls. List of tracker ids for the events that require a subscription.
+* `trackers` - required, int array, without nulls. List of tracker ids for the events that require a subscription.
 * `events` - required, [enum](../getting-started.md#data-types) array, without nulls. List of events to subscribe. Event can be one of: `state`.
 
 Request sample:
@@ -92,7 +92,7 @@ Request parameters:
 
 * `action` - text: _"unsubscribe"_.
 * `hash` - required, string, length=32. Session hash code gotten by [user/auth](../resources/commons/user/index.md#auth) action.
-* `trackers` - required, array of int, without nulls. List of tracker ids for events that require an unsubscription.
+* `trackers` - required, int array, without nulls. List of tracker ids for events that require an unsubscription.
 * `events` - required, [enum](../getting-started.md#data-types) array, without nulls. List of events to unsubscribe. Event can be `state`.
 
 Request sample:
@@ -113,7 +113,7 @@ Response parameters:
 * `type` - required, text: _"response"_.
 * `action` - required, text: _"subscription/unsubscribe"_.
 * `events` - required, [enum](../getting-started.md#data-types) array, without nulls. List of unsubscribed events. Event can be `state`.
-* `data` - required, array of int, without nulls. List of tracker ids from request.
+* `data` - required, int array, without nulls. List of tracker ids from request.
 
 Response sample:
 

--- a/docs/backend-api/websocket/websocket.md
+++ b/docs/backend-api/websocket/websocket.md
@@ -39,13 +39,13 @@ Note what:
 
 In a simplified form, opening the WebSocket using [atmosphere-javascript](https://github.com/Atmosphere/atmosphere-javascript) looks like this:
 
-```js
+```json
 var request = {
     url: 'https://domain.com/event/subscription',
     contentType: "application/json",
     transport: 'websocket'
 };
-atmosphere.subscribe(request);
+atmosphere.subscribe(request)
 ```
 
 Executing this code will lead to send a request

--- a/docs/general/getting-started.md
+++ b/docs/general/getting-started.md
@@ -7,7 +7,41 @@ description: Getting started with Navixy API
 
 ## How to read this documentation
 
-Coming soon.
+The documentation is presented in several sections that are responsible for its own part of the Navixy platform:
+
+* `General` - introductory section. Explains how to work with the documentation and how you can help us improve it. It 
+also has information regarding translation of the platform into different languages.
+* `Backend API` - describes all calls for working with information presented to users or sub-users in the UI. Tracking, 
+reports, tasks, and more.
+* `Panel-API` - describes all calls for working with information presented to administrators in the admin panel. 
+Information about devices, tariff plans, users, and more.
+* `Frontend` - provides information on customizing the welcome page and additional Weblocator and Delivery plugins.
+
+You can switch between sections using menu on the top of the page. On the right side of the menu, you can find a button 
+for downloading a PDF version of documentation and a link to our `github` page. 
+
+All files of the section are presented in menu on the left. Once you click on one of them - it will display file contents. 
+On the right side of page you can find file's internal menu. Use it for quick navigation between parts of the file.
+
+The documentation has three types of files: documents, guides and API calls.
+
+Documents and guides are divided into semantic parts, the first of which is an introduction that briefly describes 
+what the document is about.
+
+API calls have the following structure:
+
+* `Introduction` - API call description and general information about its purpose.
+* `The structure of the object` - describes an object that is used in the calls. (optional)
+* `API-actions` - the API base call and actions. All API-actions also divided into several points:
+    * `Description of the API-actions` - describes purpose of the call.
+    * `Requirements` - what rights are required to use the API-action. (optional)
+    * `Parameters table` - contains list of parameters for selected API call, their description and data type.
+    * `Examples` - example of a correct API call with all parameters listed. Examples can be useful for troubleshooting. 
+    You can also copy them and simply substitute the data with your own. Each example has a copy button in the upper right 
+    corner. If the parameters don't contain special characters, they are presented in two variants: POST and GET. If the 
+    parameters include special characters, only POST examples given.
+    * `Response` - an example of successful response from the server with description of every field.
+    * `Errors` - specific errors for this API-action. General error list applies to all calls.
 
 ## Get involved
 

--- a/docs/general/overview.md
+++ b/docs/general/overview.md
@@ -1,6 +1,8 @@
 ---
+title: Getting Started
 description: Overview of Navixy developers public documentation
 ---
+
 <!-- drop the spaces between { { and } } -->
 <!-- Get involved: [github]({ { config.repo_url } }) -->
 <!-- { { macros_info() } } -->
@@ -16,3 +18,6 @@ API and technical documentation for developers and partners.
   [1]: https://www.navixy.com/
   [2]: https://squaregps.com/
 
+All calls and methods will allow you to develop an application that pulls all the necessary information from the platform.
+By combining and processing the information you receive you will be able to cover the needs of your customers and partners 
+by providing them with a customized app. More personalized solution can attract more customers and increase their loyalty.

--- a/docs/panel-api/resources/tracker.md
+++ b/docs/panel-api/resources/tracker.md
@@ -431,7 +431,7 @@ The action is considered completed successfully, even if some of the trackers co
 
 | Name | Description  | Type |
 | --- | --- | --- |
-| `trackers` | Tracker ID list. Each of these trackers must be a clone and be accessible for current user. |array of integers |
+| `trackers` | Tracker ID list. Each of these trackers must be a clone and be accessible for current user. | int array |
 
 **Return**
 

--- a/docs/panel-api/resources/user.md
+++ b/docs/panel-api/resources/user.md
@@ -174,7 +174,7 @@ entities will be returned only if filter string is contained within one of the f
 | `offset` | Starting offset, used for pagination | int, optional (default: 0) |
 | `hide_inactive` | If true only activated users will be returned |  boolean, optional (default: false) |
 | `format` | xlsx or csv | string, optional (default: xlsx) |
-| `columns` | list of columns to export | array of string, (default: ["id", "login", "first_name", "middle_name", "last_name", "phone"]) |
+| `columns` | list of columns to export | string array, (default: ["id", "login", "first_name", "middle_name", "last_name", "phone"]) |
 
 About user object structure see [above](#data-structures).
 


### PR DESCRIPTION
- Added more attractive info to overview.md
- Added how to read this documentation on getting-started.md
- Changed data types in all places. Array of string -> string array, array of int - int array. So more correct.
Sorry I have mismanaged the branch and got all previous commits there. Only the last commit with real changes.