### PR TITLE
Update of place/index.md - error on create example

### DIFF
--- a/docs/backend-api/resources/field_service/place/index.md
+++ b/docs/backend-api/resources/field_service/place/index.md
@@ -207,7 +207,7 @@ Creates a new POI.
 === "cURL"
 
     ```shell
-    curl -X POST '{{ extra.api_example_url }}/place/read' \
+    curl -X POST '{{ extra.api_example_url }}/place/create' \
         -H 'Content-Type: application/json' \ 
         -d '{"hash": "22eac1c27af4be7b9d04da2ce1af111b", "place": {"icon_id" : 55, "avatar_file_name": null, "location": {"lat": 40.773998, "lng": -73.66003, "address": "730 5th Ave, New York, NY 10019, Unites States", "radius": 50}, "fields": {"131312": {"type": "text", "value": "I love text!"}}, "label": "Crown Building", "description": "Here we buy our goods", "tags": [1, 2], "external_id": "1"}'
     ```


### PR DESCRIPTION
The example url to create a Place is wrong.
The endpoint is 'read' instead of 'create'.

Replace ```curl -X POST '{{ extra.api_example_url }}/place/read' with curl -X POST '{{ extra.api_example_url }}/place/create```