### PR TITLE
Data Warehouse API to Raw IoT Data API

### DIFF
--- a/docs/user-api/data-warehouse-api/.pages.yml
+++ b/docs/user-api/data-warehouse-api/.pages.yml
@@ -1,4 +1,4 @@
-title: Data Warehouse API
+title: Raw IoT Data API
 nav:
   - getting-started.md
   - guides

--- a/docs/user-api/data-warehouse-api/getting-started.md
+++ b/docs/user-api/data-warehouse-api/getting-started.md
@@ -1,14 +1,14 @@
 ---
 title: Getting Started
-description: Overview of Navixy Data Warehouse API.
+description: Overview of Navixy Raw IoT Data API.
 ---
-# Navixy Data Warehouse API
+# Navixy Raw IoT Data API
 
 Navixy Data Warehouse (DWH) API is a powerful tool designed for developers and data engineers who need access to comprehensive, raw data from GPS and telematics devices. This API allows you to extract unprocessed data with high granularity, enabling detailed analysis and customized solutions. With the Navixy DWH API, you can seamlessly integrate with our platform, retrieve essential data, and leverage it for various applications, including analytics, reporting, and data science.
 
 ## Overview
 
-The structure of the Data Warehouse API is mostly similar to the [Backend API](../backend-api/getting-started/introduction.md). If you're familiar with the basics of the user API, you will find this API intuitive and easy to work with. The DWH API provides robust methods to access raw, unprocessed data, ensuring you can harness the full potential of your connected devices.
+The structure of the Raw IoT Data API is mostly similar to the [Backend API](../backend-api/getting-started/introduction.md). If you're familiar with the basics of the user API, you will find this API intuitive and easy to work with. The DWH API provides robust methods to access raw, unprocessed data, ensuring you can harness the full potential of your connected devices.
 
 ## Time Frame Limits
 
@@ -16,7 +16,7 @@ The Data Warehouse (DW) API allows you to request raw data for periods ranging f
 
 ## Base URL
 
-Data Warehouse API resides in the `dwh` subsection of the API URL and does not belong to backend APIv2. You need to determine the URL to API calls like this:
+Raw IoT Data API resides in the `dwh` subsection of the API URL and does not belong to backend APIv2. You need to determine the URL to API calls like this:
 * `https://api.eu.navixy.com/dwh/v1` for the European Navixy ServerMate platform.
 * `https://api.us.navixy.com/dwh/v1` for the American Navixy ServerMate platform.
 
@@ -34,7 +34,7 @@ Authentication is handled by the [Backend API](../backend-api/getting-started/au
 
 ### Authorization
 
-Requests to the Data Warehouse API are made using a user session hash or API key. It can be passed as the Authorization HTTP header with the NVX auth scheme or within a `-d` (data) command.
+Requests to the Raw IoT Data API are made using a user session hash or API key. It can be passed as the Authorization HTTP header with the NVX auth scheme or within a `-d` (data) command.
 
 Example:
 
@@ -128,4 +128,4 @@ curl -X 'POST' \
   }'
 ```
 
-By leveraging the Navixy Data Warehouse API, developers and data engineers can access and analyze detailed raw data from their GPS and telematics devices, enabling a wide range of custom solutions and insights.
+By leveraging the Navixy Raw IoT Data API, developers and data engineers can access and analyze detailed raw data from their GPS and telematics devices, enabling a wide range of custom solutions and insights.

--- a/docs/user-api/data-warehouse-api/guides/raw-data.md
+++ b/docs/user-api/data-warehouse-api/guides/raw-data.md
@@ -4,7 +4,7 @@ description: How to request raw tracker data from Navixy Data Warehouse and typi
 ---
 # Requesting Raw Data
 
-Navixy Data Warehouse API allows telematics solution providers and developers of location-based solutions to access comprehensive, unprocessed data from tracking devices. This enables accurate information retrieval and a deeper understanding of collected data, facilitating issue resolution and integration into other systems for extensive analysis and business use.
+Navixy Raw IoT Data API allows telematics solution providers and developers of location-based solutions to access comprehensive, unprocessed data from tracking devices. This enables accurate information retrieval and a deeper understanding of collected data, facilitating issue resolution and integration into other systems for extensive analysis and business use.
 
 ## Typical Use Case
 
@@ -88,7 +88,7 @@ In addition, we will use names for inputs according to the information obtained 
 
 !!! note "We specify `inputs.lls_level_1` because we know that our device only sends data on this input. If we didn't know the input number, we could have specified all four possible inputs, and then the inputs without data would just get zero values."
 
-The API request [`raw_data/read`](../resources/tracker/raw_data#read) for reading the required raw data in our case should look like this:
+The API request [`raw_data/read`](../resources/tracker/raw_data.md#read) for reading the required raw data in our case should look like this:
 
 === "cURL"
 
@@ -146,7 +146,7 @@ When requesting raw data, you must specify the exact period for which you need t
 
 Similar to the [Backend API](../../backend-api/getting-started/introduction.md), you can specify the date and time in either the standard `YYYY-MM-DD HH:mm:ss` format with or without a time zone or in ISO 8601 format. 
 
-The default format for Data Warehouse API requests is ISO 8601.
+The default format for Raw IoT Data API requests is ISO 8601.
 
 The platform allows you to request raw data for any period within the [time frame limits](../getting-started.md#time-frame-limits).
 

--- a/docs/user-api/data-warehouse-api/resources/tracker/raw_data.md
+++ b/docs/user-api/data-warehouse-api/resources/tracker/raw_data.md
@@ -4,7 +4,7 @@ description: Contains API calls to retrieve trackers raw data.
 ---
 # Raw Data
 
-The Navixy Data Warehouse API allows you to retrieve all the data sent by your devices within the last 30 days in a raw format.
+The Navixy Raw IoT Data API allows you to retrieve all the data sent by your devices in a raw format.
 
 !!! note "Parsed raw data — Data obtained immediately after decoding (parsing) incoming data packets, considering the protocol and specifics of the device model from which the packets were received."
 
@@ -17,7 +17,7 @@ You can access various types of data that your devices send, such as:
 * Status of inputs and outputs,
 * Other attributes.
 
-The Navixy Data Warehouse API provides the following key methods:
+The Navixy Raw IoT Data API provides the following key methods:
 
 - **`get_inputs`**: To retrieve a list of available attributes from a device to understand which ones can be requested in a file.
 - **`read`**: To get a CSV file with decoded data values sent by tracking devices.
@@ -303,7 +303,7 @@ curl -X 'POST' \
 
 
 <video controls style="width: 100%; height: auto;">
-  <source src="../tracker/assets/videos/1_parquet_curl_linux.mp4" type="video/mp4">
+  <source src="../assets/videos/1_parquet_curl_linux.mp4" type="video/mp4">
   Your browser does not support the video tag.
 </video>
 

--- a/docs/user-api/getting-started.md
+++ b/docs/user-api/getting-started.md
@@ -3,7 +3,7 @@ that users have access to in the user interface.
 
 Here are the following sections:
 
-* [**Data Warehouse API**](./data-warehouse-api/getting-started.md): In this section, you will learn how to access raw 
+* [**Raw IoT Data API**](./data-warehouse-api/getting-started.md): In this section, you will learn how to access raw 
 data from trackers received by the platform.
 * [**Backend API**](./backend-api/getting-started/introduction.md): In this section, you will find API calls that allow 
 you to retrieve all the information available to users on the platform. This includes data and actions related to trackers, 


### PR DESCRIPTION
- Changed the section name to "Raw IoT Data API."
- Updated all mentions of "Data Warehouse API" to "Raw IoT Data API." 
- Corrected the link to the raw-data docs and the video instructions for downloading parquet files.