### PR TITLE
Notes and Warning syntax fix

### DIFF
--- a/docs/general/contribute/dev-docs.md
+++ b/docs/general/contribute/dev-docs.md
@@ -4,7 +4,7 @@ description: Get involved into improving documentation and translations of the N
 ---
 # Contributing to Developer documentation
 
-Join us in enhancing Navixy developer documentation! Your contributions are highly valued and appreciated. Whether you’ve spotted an inaccuracy, found a typo, or have additional information to share, your help is appreciated. All our documentation is publicly available on [GitHub]({{ config.repo_url }}), and you can get involved in several ways to make it better:
+Join us in enhancing Navixy developer documentation! Your contributions are highly valued and appreciated. Whether you’ve spotted an inaccuracy, found a typo, or have additional information to share, your help is appreciated. All our documentation is publicly available on [GitHub](https://github.com/SquareGPS/navixy-api), and you can get involved in several ways to make it better:
 
 1. [Creating an issue with a detailed description of the problem.](https://github.com/SquareGPS/navixy-api/issues/new) 
 2. [Editing a single page in a browser](#quick-edits-in-the-browser).

--- a/docs/general/zapier.md
+++ b/docs/general/zapier.md
@@ -105,6 +105,7 @@ Choose one of the following actions based on your device and use case.
 
 Activate your Zap to start the automation. Ensure your device is online to receive commands.
 
-!!! warning "Switching off the engine of a moving vehicle can lead to serious accidents and is extremely dangerous. This action should only be performed under safe conditions, such as when the vehicle is stationary and secured. Navixy is not liable for any accidents, injuries, or damages resulting from the improper use of this functionality."
+<!-- theme: warning -->
+> Switching off the engine of a moving vehicle can lead to serious accidents and is extremely dangerous. This action should only be performed under safe conditions, such as when the vehicle is stationary and secured. Navixy is not liable for any accidents, injuries, or damages resulting from the improper use of this functionality.
 
 For detailed steps and more examples, refer to the [Navixy documentation](../general/getting-started.md).

--- a/docs/panel-api/getting-started.md
+++ b/docs/panel-api/getting-started.md
@@ -23,7 +23,7 @@ The Admin Panel API is accessible via the `panel/` subsection of the API URL. Th
 
 For example, to make an `account/auth` API call on the Navixy ServerMate platform, you would use the following URL:
 
-    {{ extra.api_example_url }}/panel/account/auth
+`{{ extra.api_example_url }}/panel/account/auth`
 
 ### Authorization
 
@@ -37,15 +37,14 @@ Keep in mind that any string containing symbols outside ASCII codes 32 to 127 mu
 
 In on-premise installations, there is a default user with login `admin` and password `admin`. You can authorize with these credentials as follows (all HTTP request examples are made using the [curl](https://curl.haxx.se/) *nix utility):
 
-##### POST Request
-```sh
+```POST 
 $ curl -d 'login=admin&password=admin' \
        -X POST http://api.domain.com/v2/panel/account/auth/
 ```
 
-##### GET Request
-This method is not recommended and provided just for example:
-```sh
+```GET 
+//This method is not recommended and provided just for example:
+
 $ curl http://api.domain.com/panel/v2/account/auth/?login=admin&password=admin
 ```
 

--- a/docs/panel-api/resources/user/index.md
+++ b/docs/panel-api/resources/user/index.md
@@ -7,7 +7,7 @@ description: API calls on work with users in the admin panel.
 
 In the Navixy Admin Panel, a User refers to the accounts of Organizations or Individuals who are customers of the Dealer (or Sub Dealer). For example, an organization 'ABC Inc.' can be a User with the type "legal_entity," and John Doe can be a User with the type "individual."
 
-!!! note "User accounts may have additional sub-accounts, commonly referred to as 'sub-users,' allowing larger organizations to grant access to multiple employees."
+> User accounts may have additional sub-accounts, commonly referred to as 'sub-users,' allowing larger organizations to grant access to multiple employees.
 
 This page describes the User object and the API actions that can be performed with it within the Admin Panel.
 

--- a/docs/panel-api/resources/user/mfa/settings.md
+++ b/docs/panel-api/resources/user/mfa/settings.md
@@ -1,8 +1,9 @@
 # Multi-factor authentication settings
 
-!!! warning "Work in progress"
-    This API is a work in progress and may change in future releases.
-    In this version allowing MFA to a user automatically enables it for them.
+<!-- theme: warning -->
+> **Work in progress!** <br>
+> This API is a work in progress and may change in future releases.<br>
+> In this version, allowing MFA to a user automatically enables it for them.
 
 ## API actions
 

--- a/docs/user-api/backend-api/guides/field-service-management/check-ins.md
+++ b/docs/user-api/backend-api/guides/field-service-management/check-ins.md
@@ -2,7 +2,7 @@
 
 In Navixy, check-ins are a feature used to record and report the location and status of employees in the field. They allow employees to send real-time updates about their location, accompanied by additional data such as forms, photos, and comments. These check-ins can be used for various purposes, including verifying task completion, providing updates on job progress, and collecting field data. Check-ins are typically created using the X-GPS Tracker mobile app and can be integrated into workflows to ensure accurate and timely information from field employees.
 
-!!! note "Check-ins are normally created using X-GPS Tracker mobile app. The description below is necessary only for non-standard use, such as creating your own Mobile Tracker app that works with the Navixy platform."
+> Check-ins are normally created using X-GPS Tracker mobile app. The description below is necessary only for non-standard use, such as creating your own Mobile Tracker app that works with the Navixy platform.
 
 To create check-ins in the Navixy platform, follow these steps:
 

--- a/docs/user-api/backend-api/guides/field-service-management/create-forms.md
+++ b/docs/user-api/backend-api/guides/field-service-management/create-forms.md
@@ -89,7 +89,7 @@ Forms can be filled in two ways:
 
 A form can be assigned to an existing task with the [task update](../../resources/field_service/task/index.md#update) call or used during [task creation](../../resources/field_service/task/index.md#create).
 
-!!! note "`create_form` parameter should be `false` to add an already created form."
+> `create_form` parameter should be `false` to add an already created form.
 
 ## Retrieving Information from Submitted Forms
 

--- a/docs/user-api/backend-api/guides/places/manage-pois.md
+++ b/docs/user-api/backend-api/guides/places/manage-pois.md
@@ -26,31 +26,31 @@ For our CRM system, we need the following fields:
 
 Some fields are default and cannot be changed (Label, Address, Description, and Tags). All other necessary fields should be created manually.
 
-!!!note "Custom fields added here will be available for all places."
+> Custom fields added here will be available for all places.
 
 First, get the entity ID to identify which entity to update and where to add fields.
 
 **API Request:**
 
-=== "cURL"
+#### cURL
 
-    ```shell
-    curl -X POST '{{ extra.api_example_url }}/entity/list' \
-        -H 'Content-Type: application/json' \
-        -d '{"hash": "a6aa75587e5c59c32d347da438505fc3"}'
-    ```
+```shell
+curl -X POST '{{ extra.api_example_url }}/entity/list' \
+     -H 'Content-Type: application/json' \
+     -d '{"hash": "a6aa75587e5c59c32d347da438505fc3"}'
+```
 
 The response will provide the necessary entity ID with existing fields. Add new fields to this entity. Only add fields that do not already exist.
 
 **API Request:**
 
-=== "cURL"
+#### cURL
 
-    ```shell
+```shell
     curl -X POST '{{ extra.api_example_url }}/entity/fields/update' \
         -H 'Content-Type: application/json' \
         -d '{"hash": "a6aa75587e5c59c32d347da438505fc3", "delete_missing": true, "entity_id": 520, "fields": [{"label": "E-mail", "required": false, "type": "email", "description": "Customer\'s email"}, {"label": "Phone", "required": false, "type": "phone", "description": "Customer\'s phone"}, {"label": "The last visit date", "required": false, "type": "text", "description": null}, {"label": "The last order №", "required": false, "type": "text", "description": null}, {"label": "The last visit result", "required": false, "type": "text", "description": null}, {"label": "Responsible employee", "params": {"responsible": true}, "required": false, "type": "employee", "description": null}]}'
-    ```
+```
 
 The platform will confirm the update with:
 

--- a/docs/user-api/backend-api/resources/billing/bill.md
+++ b/docs/user-api/backend-api/resources/billing/bill.md
@@ -128,7 +128,7 @@ Shows list of bills with their parameters in array.
 
 If bill created using [/bill/create](#create) call then **positions** will contain exactly one element.
 
-!!! note "For Standalone version base part of **link** may be changed by **billing.orders.baseUrl** config option."
+> For Standalone version base part of **link** may be changed by **billing.orders.baseUrl** config option.
 
 #### Errors
 

--- a/docs/user-api/backend-api/resources/commons/api-keys.md
+++ b/docs/user-api/backend-api/resources/commons/api-keys.md
@@ -18,14 +18,14 @@ Unlike the user's session:
 * you can create a separate key for each individual integration.
 * if request rate limit is exceeded, regular users will not be blocked, because API keys have a separate counter.
 
-!!! note "You can get an API key in user's web interface. This is the recommended way instead of user session hash."
+> You can get an API key in user's web interface. This is the recommended way instead of user session hash.
 
 In one user's account, you can have up to 20 API keys intended for different external integrations. 
 To distinguish keys from each other, you should give them meaningful names.
 
-!!! warning "Security"
-    Do not publish API keys anywhere. Having a key, you can perform almost any action in the 
-    user's account. Make API calls only over HTTPS because the key is transmitted in cleartext.
+<!-- theme: warning -->
+> Security
+> Do not publish API keys anywhere. Having a key, you can perform almost any action in the user's account. Make API calls only over HTTPS because the key is transmitted in cleartext.
 
 Find more details on API keys usage in our [instructions](../../getting-started/authentication.md).
 

--- a/docs/user-api/backend-api/resources/commons/entity/fields.md
+++ b/docs/user-api/backend-api/resources/commons/entity/fields.md
@@ -127,7 +127,8 @@ All fields associated with the same entity must have different `label`s.
 
 Passing fields with `id` from non-existent fields or fields bound to another entity will result in an error.
 
-!!! warning "If `delete_missing` is `true`, all existing fields which are missing from the `fields` list will be permanently deleted! Otherwise, they are unaffected."
+<!-- theme: warning -->
+> If `delete_missing` is `true`, all existing fields which are missing from the `fields` list will be permanently deleted! Otherwise, they are unaffected.
 
 #### Parameters
 

--- a/docs/user-api/backend-api/resources/commons/entity/index.md
+++ b/docs/user-api/backend-api/resources/commons/entity/index.md
@@ -127,7 +127,7 @@ Gets entity by the ID or by type.
 | id   | ID of an entity.                                  | int    |
 | type | Type of an entity. Entity type string, see above. | string |
 
-!!! note "Exactly one of these parameters must be specified. They can't be both null or both non-null."
+> Exactly one of these parameters must be specified. They can't be both null or both non-null.
 
 #### Examples
 
@@ -195,7 +195,8 @@ Updates settings of customizable entity. Entity must have a valid ID.
 
 **required sub-user rights**: `places_custom_fields_update` for entities with type `place`.
 
-!!! warning "`entity.settings.layout.sections` must contain IDs of all builtin and custom fields which are associated with this entity. No fields can be omitted from layout, only reordering allowed. Fields cannot be duplicated, even in different sections."
+<!-- theme: warning -->
+> `entity.settings.layout.sections` must contain IDs of all builtin and custom fields which are associated with this entity. No fields can be omitted from layout, only reordering allowed. Fields cannot be duplicated, even in different sections.
 
 #### Parameters
 

--- a/docs/user-api/backend-api/resources/commons/entity/search_conditions.md
+++ b/docs/user-api/backend-api/resources/commons/entity/search_conditions.md
@@ -41,7 +41,8 @@ Search conditions are represented by an array of conditions, where each conditio
 ]
 ```
 
-!!! warning "A maximum of 72 conditions can be used at once, including nested conditions."
+<!-- theme: warning -->
+> A maximum of 72 conditions can be used at once, including nested conditions.
 
 
 ## Condition Types

--- a/docs/user-api/backend-api/resources/commons/plugin/report_plugins.md
+++ b/docs/user-api/backend-api/resources/commons/plugin/report_plugins.md
@@ -492,7 +492,7 @@ Plugin-specific parameters:
 }
 ```
 
-!!! note "Parameter `details_interval_minutes` is deprecated. Please use `details_interval_seconds`."
+> Parameter `details_interval_minutes` is deprecated. Please use `details_interval_seconds`.
 
 #### plugin example
 
@@ -633,7 +633,7 @@ Plugin-specific parameters:
 }
 ```
 
-!!! note "Param `details_interval_minutes` is deprecated. Please sue `details_interval_seconds`."
+> Param `details_interval_minutes` is deprecated. Please sue `details_interval_seconds`.
 
 #### plugin example
 

--- a/docs/user-api/backend-api/resources/commons/subuser/places.md
+++ b/docs/user-api/backend-api/resources/commons/subuser/places.md
@@ -27,7 +27,8 @@ Gives access for sub-user to specified places.
 | access_to_all | Optional. If `true` then sub-user will have access to all places of master user.                                   | boolean   |
 | place_ids     | Optional. List of place IDs to associate with a specified sub-user. All places must belong to current master user. | int array |
 
-!!! warning "At least one of **access_to_all** and **place_ids** parameters must be not null."
+<!-- theme: warning -->
+> At least one of **access_to_all** and **place_ids** parameters must be not null.
 
 #### Examples
 

--- a/docs/user-api/backend-api/resources/commons/subuser/zones.md
+++ b/docs/user-api/backend-api/resources/commons/subuser/zones.md
@@ -27,7 +27,8 @@ Gives access for sub-user to specified geofences.
 | access_to_all | Optional. If `true` then sub-user will have access to all geofences of master user.                                      | boolean   |
 | zone_ids      | Optional. List of geofence IDs to associate with a specified sub-user. All geofences must belong to current master user. | int array |
 
-!!! warning "At least one of **access_to_all** and **zone_ids** parameters must be not null."
+<!-- theme: warning -->
+> At least one of `access_to_all` and `zone_ids` parameters must be not null.
 
 #### Examples
 

--- a/docs/user-api/backend-api/resources/commons/user/index.md
+++ b/docs/user-api/backend-api/resources/commons/user/index.md
@@ -145,11 +145,10 @@ Activates previously registered user with the provided session hash
 (it is contained in activation link from email sent to user).
 Available only to master users.
 
-!!! attention 
-    This call will receive only session hash from registration email.
-    Any other hash will result in result error code 4 (User or API key not found or session ended).
-    The only thing that API calls with a user session will work for is creating, 
-    reading, and deleting API keys.
+<!-- theme: danger -->
+> This call will receive only session hash from registration email. <br>
+> Any other hash will result in result error code 4 (User or API key not found or session ended).
+> The only thing that API calls with a user session will work for is creating, reading, and deleting API keys.
 
 #### Response
 
@@ -165,7 +164,7 @@ Tries to authenticate the user and get hash.
 
 It does not need authentication/hash and is available at `UNAUTHORIZED` access level.
 
-!!! note "It is strongly recommended using [API keys](../../../getting-started/authentication.md) instead of user session hash."
+> It is strongly recommended using [API keys](../../../getting-started/authentication.md) instead of user session hash.
 
 #### Parameters
 

--- a/docs/user-api/backend-api/resources/commons/user/password.md
+++ b/docs/user-api/backend-api/resources/commons/user/password.md
@@ -18,7 +18,7 @@ API path: `/user/password`.
 Changes password of user with the provided session hash (it is contained in a password restore link from email sent to
  user by user/restore_password).
 
-!!! note "This call will receive only session hash from a password restore email. Any other hash will result in result  error code 4 (User or API key not found or session ended)."
+> This call will receive only session hash from a password restore email. Any other hash will result in result  error code 4 (User or API key not found or session ended).
 
 #### Parameters
 

--- a/docs/user-api/backend-api/resources/field_service/task/checkpoint.md
+++ b/docs/user-api/backend-api/resources/field_service/task/checkpoint.md
@@ -62,7 +62,7 @@ Every route consists of checkpoints. Using these actions, you can manipulate che
 * `form` - [form object](../form/index.md#form-object). If present.
 * `form_template_id` - int. An ID of form template. Used in create and update actions only if `create_form` parameter is `true` in them.
 
-!!! note "To associate the task with an address - this field should be added to the location object."
+> To associate the task with an address - this field should be added to the location object.
 
 
 ## API actions

--- a/docs/user-api/backend-api/resources/field_service/task/index.md
+++ b/docs/user-api/backend-api/resources/field_service/task/index.md
@@ -77,7 +77,7 @@ Find more guides on working with tasks [there](../../../guides/field-service-man
 * `form_template_id` - int. An ID of form template. Used in create and update actions only if `create_form` parameter is `true` in them.
 * `fields` - optional object. A map, each key of which is a custom field ID *as a string*. See [entity/fields](../../commons/entity/fields.md)
 
-!!! note "To associate the task with an address - this field should be added to the location object."
+> To associate the task with an address - this field should be added to the location object.
 
 
 ## API actions

--- a/docs/user-api/backend-api/resources/fleet/vehicle/status_listing/listing.md
+++ b/docs/user-api/backend-api/resources/fleet/vehicle/status_listing/listing.md
@@ -5,8 +5,9 @@ description: Contains vehicle status listing object and API calls to interact wi
 
 # Vehicle status listing
 
-!!! warning "Deprecated"
-    This API action deprecated and should not be used.
+<!-- theme: warning -->
+> **Deprecated!**<br>
+> This API action deprecated and should not be used.
 
 Contains vehicle status listing object and API calls to interact with it.
 

--- a/docs/user-api/backend-api/resources/tracking/track/index.md
+++ b/docs/user-api/backend-api/resources/tracking/track/index.md
@@ -50,9 +50,8 @@ The data should cover trips starting from 3:24 AM to 6:24 AM on November 19, 202
 
 In case the available storage period is not exceeded, you will get the file.
 
-!!! example "KML file example with two points"
-
-    ```xml
+<!-- title: "KML file example with two points" -->
+```xml
     <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
     <kml xmlns="http://www.opengis.net/kml/2.2" xmlns:gx="http://www.google.com/kml/ext/2.2" xmlns:atom="http://www.w3.org/2005/Atom" xmlns:xal="urn:oasis:names:tc:ciq:xsdschema:xAL:2.0">
       <Document>
@@ -97,7 +96,7 @@ In case the available storage period is not exceeded, you will get the file.
         </Placemark>
       </Document>
     </kml>
-    ```
+```
 
 For example, if the device's plan has maximum available storage period 3 months (default value) and we request data from 
 6 months, the response will contain JSON with the next information: 
@@ -112,10 +111,8 @@ For example, if the device's plan has maximum available storage period 3 months 
 
 #### Errors
 
-* 201 - Not found in database – the tracker ID in your request may not match any trackers linked to the user account with this 
-session hash. Ensure the correct tracker_id and hash of an appropriate user are used.
-* 208 - Device blocked – if a tracker exists under this user account but is currently inactive due to tariff plan 
-restrictions or any other reason.
+* 201 - Not found in database – the tracker ID in your request may not match any trackers linked to the user account with this session hash. Ensure the correct tracker_id and hash of an appropriate user are used.
+* 208 - Device blocked – if a tracker exists under this user account but is currently inactive due to tariff plan restrictions or any other reason.
 * 211 - Requested time span is too big – If the interval between the "from" and "to" dates is too large, it may exceed 
 the maximum value defined in the API configuration.
 

--- a/docs/user-api/backend-api/resources/tracking/tracker/contact.md
+++ b/docs/user-api/backend-api/resources/tracking/tracker/contact.md
@@ -4,8 +4,9 @@ description: API call to get user's trackers with special grouping by "contacts"
 ---
 # Contact 
 
-!!! warning "Deprecated"
-    This API action deprecated and should not be used.
+<!-- theme: warning -->
+> **Deprecated!**<br>
+> This API action deprecated and should not be used.
 
 API call to get user's trackers with special grouping by "contacts"
 

--- a/docs/user-api/backend-api/resources/tracking/tracker/index.md
+++ b/docs/user-api/backend-api/resources/tracking/tracker/index.md
@@ -1513,10 +1513,10 @@ Find detailed instructions on tracker registration [there](../../../guides/devic
 
 #### Parameters
 
-!!! warning "Important"
-    Because of the variety of tracker models and business applications, there are different ways to 
-    register tracker in our system. They are called [Registration plugins](../../commons/plugin/index.md). 
-    Each of registration plugins has its own set of additional parameters.
+<!-- theme: warning -->
+> **Important!**<br> 
+> Because of the variety of tracker models and business applications, there are different ways to register tracker in our system. They are called [Registration plugins](../../commons/plugin/index.md).<br> 
+> Each of registration plugins has its own set of additional parameters.
 
 In addition to parameters specified in this section, pass all parameters which are required by the
 plugin you have chosen. See example below.
@@ -1763,13 +1763,11 @@ Replacement allows you to register a new device with history, sensors (optional)
 
 #### Parameters
 
-!!! warning "Important"
-    Because of the variety of tracker models and business applications, there are different ways to
-    register a new tracker in our system. They are called [Registration plugins](../../commons/plugin/index.md).
-    Each of registration plugins has its own set of additional parameters.
-    <br/>
-    In addition to parameters specified in this section, pass all parameters which are required by the
-    plugin you have chosen. See example below.
+<!-- theme: warning -->
+> **Important!** <br>
+> Because of the variety of tracker models and business applications, there are different ways to register a new tracker in our system. They are called [Registration plugins](../../commons/plugin/index.md).
+> Each of registration plugins has its own set of additional parameters.<br/>
+> In addition to parameters specified in this section, pass all parameters which are required by the plugin you have chosen. See example below.
 
 Common parameters are:
 

--- a/docs/user-api/backend-api/resources/tracking/tracker/mobile.md
+++ b/docs/user-api/backend-api/resources/tracking/tracker/mobile.md
@@ -4,8 +4,9 @@ description: API call to register a mobile application. Deprecated.
 ---
 # Mobile app register
 
-!!! warning "Deprecated"
-    This API action deprecated and should not be used.
+<!-- theme: warning -->
+> **Deprecated!**<br>
+> This API action deprecated and should not be used.
 
 API call to register a mobile application. Use [tracker/register](index.md#register) with `plugin_id` 35.
 

--- a/docs/user-api/backend-api/resources/tracking/tracker/sensor/index.md
+++ b/docs/user-api/backend-api/resources/tracking/tracker/sensor/index.md
@@ -412,8 +412,9 @@ in use.
 
 Copies sensors from one tracker to another.
 
-!!! warning "Important"
-    This operation will delete sensors of target trackers, and some sensor data could be lost!
+<!-- theme: warning -->
+> **Important!**<br>
+> This operation will delete sensors of target trackers, and some sensor data could be lost!
 
 **required sub-user rights:** `tracker_update`.
 

--- a/docs/user-api/backend-api/resources/tracking/zone/index.md
+++ b/docs/user-api/backend-api/resources/tracking/zone/index.md
@@ -500,13 +500,11 @@ Gets all geofence IDs and names within which a specified coordinates are located
 
 Update geofence parameters for the specified geofence.
 
-!!! note "Notes"
-
-    - The geofence must exist, belong to the current user, and its type cannot be modified.
-    For example, if you already have a geofence with ID=1 of type "circle",
-    you cannot submit a geofence with the same ID but of type "polygon".
-    - If the `zone` object is of type `sausage` or `polygon` and contains an array of points, these points will be updated.
-    Alternatively, you can update the points using the [zone/point/update](zone_point.md#update) endpoint.
+> ### Notes:
+> - The geofence must exist, belong to the current user, and its type cannot be modified.
+>     For example, if you already have a geofence with ID=1 of type "circle",
+>     you cannot submit a geofence with the same ID but of type "polygon".
+> - If the `zone` object is of type `sausage` or `polygon` and contains an array of points, these points will be updated. Alternatively, you can update the points using the [zone/point/update](zone_point.md#update) endpoint.
 
 **required sub-user rights**: `zone_update`.
 
@@ -730,8 +728,7 @@ Download geofences as KML File.
 
 A KML/KMZ file with the points (standard file download).
 
-!!! example "Example of a KML file with different geofences"
-
+<!-- title: "Example of a KML file with different geofences" -->
 ```xml
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
 <kml xmlns:gx="http://www.google.com/kml/ext/2.2" xmlns="http://www.opengis.net/kml/2.2" xmlns:atom="http://www.w3.org/2005/Atom" xmlns:xal="urn:oasis:names:tc:ciq:xsdschema:xAL:2.0">

--- a/docs/user-api/backend-api/websocket/events.md
+++ b/docs/user-api/backend-api/websocket/events.md
@@ -15,7 +15,7 @@ All event messages contain the next fields:
 
 ## State event
 
-!!! note "Can be used for 100 devices. If there are more devices, please use state batch event"
+> Can be used for 100 devices. If there are more devices, please use state batch event.
 
 These messages are coming from server if client [subscribed](subscription.md)
 to the `state` events of the specific tracker that not blocked. It occurs in the next cases:
@@ -71,7 +71,7 @@ Message sample:
 }
 ```
 
-!!! note "`source_id` is not a `tracker_id`."
+> `source_id` is not a `tracker_id`.
 
 
 ## State batch event
@@ -131,7 +131,7 @@ Message sample:
 }
 ```
 
-!!! note "`source_id` is not a `tracker_id`."
+> `source_id` is not a `tracker_id`.
 
 
 ### Compact source state

--- a/docs/user-api/backend-api/websocket/index.md
+++ b/docs/user-api/backend-api/websocket/index.md
@@ -28,13 +28,10 @@ Let's describe a standard workflow for WebSocket API:
 6. Subscribe and unsubscribe on the events if needed.
 7. Unsubscribe when leaving monitoring page using [unsubscribe action](subscription.md#unsubscribe-action).
 
-!!! note
-    * The [subscription requests](subscription.md) must contain the 
-      `hash` of an [API Key](../resources/commons/api-keys.md).
-    * Responses and errors for [subscribe](subscription.md#subscribe-action) 
-      and [unsubscribe](subscription.md#unsubscribe-action) actions are similar 
-      with common [API](../getting-started/introduction.md) format.
-    * All `WebSocket` frames use a `JSON` format. Exceptions are heartbeat frames containing "X".
+> ### Notes:
+> * The [subscription requests](subscription.md) must contain the `hash` of an [API Key](../resources/commons/api-keys.md).
+> * Responses and errors for [subscribe](subscription.md#subscribe-action) and [unsubscribe](subscription.md#unsubscribe-action) actions are similar with common [API](../getting-started/introduction.md) format.
+> * All `WebSocket` frames use a `JSON` format. Exceptions are heartbeat frames containing "X".
 
 
 ## Open connection

--- a/docs/user-api/backend-api/websocket/subscription.md
+++ b/docs/user-api/backend-api/websocket/subscription.md
@@ -26,11 +26,11 @@ Request parameters:
 * `hash` – required, string, length=32. Session hash code obtained by [user/auth](../resources/commons/user/index.md#auth) action.
 * `requests` – required, object array. See requests' structure below.
 
-!!! warning "Deprecated"
-    These parameters are deprecated and should not be used, please use `requests` instead:
-
-    * `trackers` – required, int array, without nulls. List of tracker IDs for the events that require a subscription.
-    * `events` – required, [enum](../getting-started/introduction.md#data-types) array, without nulls. List of events to subscribe. An event can only be a `state`.
+<!-- theme: warning -->
+> **Deprecated!**<br>
+> These parameters are deprecated and should not be used, please use `requests` instead:
+> * `trackers` – required, int array, without nulls. List of tracker IDs for the events that require a subscription.
+> * `events` – required, [enum](../getting-started/introduction.md#data-types) array, without nulls. List of events to subscribe. An event can only be a `state`.
 
 #### The "state_batch" event subscription
 

--- a/docs/user-api/data-warehouse-api/guides/raw-data.md
+++ b/docs/user-api/data-warehouse-api/guides/raw-data.md
@@ -69,7 +69,7 @@ Among the obtained inputs, we see the one of interest to us - `lls_level_4`. Thi
 
 We also see the `hw_mileage`, which will allow us to get the value of the hardware odometer.
 
-!!! note "The presence of some inputs in the received response does not mean that data is certainly available on these inputs. It means that data may come on them, but whether it is actually available or not depends on the configuration of a particular device."
+> The presence of some inputs in the received response does not mean that data is certainly available on these inputs. It means that data may come on them, but whether it is actually available or not depends on the configuration of a particular device.
 
 ## Requesting Raw Data Readings
 
@@ -86,7 +86,7 @@ In addition, we will use names for inputs according to the information obtained 
 * `inputs.lls_level_1`
 * `inputs.hw_mileage`
 
-!!! note "We specify `inputs.lls_level_1` because we know that our device only sends data on this input. If we didn't know the input number, we could have specified all four possible inputs, and then the inputs without data would just get zero values."
+> We specify `inputs.lls_level_1` because we know that our device only sends data on this input. If we didn't know the input number, we could have specified all four possible inputs, and then the inputs without data would just get zero values.
 
 The API request [`raw_data/read`](../resources/tracker/raw_data.md#read) for reading the required raw data in our case should look like this:
 
@@ -136,7 +136,7 @@ The response is returned in a CSV table format:
 
 In the above example, we see the output for one minute of tracking. When querying raw data over a long period of time, the response can reach significant sizes — this must be considered.
 
-!!! note "In one of the lines, we see `\N` instead of fuel level and mileage values. This means that no such information was received in this data packet. The `\N` symbol represents `NULL`."
+In one of the lines, we see `\N` instead of fuel level and mileage values. This means that no such information was received in this data packet. The `\N` symbol represents `NULL`.
 
 The above example is one of the simplest, but it clearly demonstrates the process of using an API request to read raw data. You can query a lot of data at once and over large periods of time, depending on your objectives.
 
@@ -280,13 +280,13 @@ or
 "to": "2023-11-30 18:00:00",
 ```
 
-!!! note "The `to` date and time must be after the `from`, otherwise the query will result in an `Invalid parameters` error."
+> The `to` date and time must be after the `from`, otherwise the query will result in an `Invalid parameters` error.
 
 ### Interval
 
 An alternative method of indicating the request period is an interval. Here you specify the start or end date and time of the period appended by the duration of the period.
 
-!!! note "When specifying the `interval` parameter, the `from` and `to` parameters must not be specified. These are mutually exclusive ways of specifying the data request period."
+> When specifying the `interval` parameter, the `from` and `to` parameters must not be specified. These are mutually exclusive ways of specifying the data request period.
 
 The interval can be specified in different forms:
 

--- a/docs/user-api/data-warehouse-api/resources/tracker/raw_data.md
+++ b/docs/user-api/data-warehouse-api/resources/tracker/raw_data.md
@@ -6,7 +6,7 @@ description: Contains API calls to retrieve trackers raw data.
 
 The Navixy Raw IoT Data API allows you to retrieve all the data sent by your devices in a raw format up to 6 months depending on your plan.
 
-!!! note "Parsed raw data — Data obtained immediately after decoding (parsing) incoming data packets, considering the protocol and specifics of the device model from which the packets were received."
+> Parsed raw data — Data obtained immediately after decoding (parsing) incoming data packets, considering the protocol and specifics of the device model from which the packets were received.
 
 On this page, you'll learn about API methods that give you access to parsed raw data, perfect for detailed analysis.
 
@@ -117,7 +117,7 @@ its tariff plan. For example, it may have been blocked because the user does not
 Retrieves parsed raw data—values received from tracking devices by the platform. Each attribute in the exported file will 
 be placed in a separate column.
 
-!!! note "The names and values of the inputs and status attributes returned by this request align with the names visible in [Air Console](https://docs.navixy.com/admin-panel/air-console) when connecting to a device. You can find them in the right column, where the incoming data is decoded."
+> The names and values of the inputs and status attributes returned by this request align with the names visible in [Air Console](https://docs.navixy.com/admin-panel/air-console) when connecting to a device. You can find them in the right column, where the incoming data is decoded.
 
 #### Request parameters
 
@@ -130,7 +130,7 @@ be placed in a separate column.
 | server_time_filter | string/object | An interval for additional filtering of messages by server time. If used, messages will be returned not only based on the message time (when the packet was registered by a tracker), but also filtered by the server time (when the message was received by the server).                                              | `"2024-02-03T10:26:26+0500/2024-02-03T10:27:18+0500"` / `{"from": "2024-02-03T10:26:26+0500", "to": "2024-02-03T10:27:18+0500"}` / `{"interval":"2024-02-03T10:26:26+0500/PT1H"}` | no       |
 | format             | string        | This is used when you need to request data in `parquet` format. If the format parameter is not provided, the default format used will be CSV.                                                                                                                                                                          | `"parquet"`                                                                                                                                                                       | no       |
 
-!!! note "Instead of using the `from`/`to` parameters, you can set the `interval` parameter — an ISO 8601 formatted interval, for example, `2023-08-24T08:04:36.306Z/PT24H`."
+> Instead of using the `from`/`to` parameters, you can set the `interval` parameter — an ISO 8601 formatted interval, for example, `2023-08-24T08:04:36.306Z/PT24H`.
 
 The response could be provided in a CSV or [Parquet](https://parquet.apache.org/docs/overview/) format file, with columns 
 predefined in the `columns` parameter of the API request. 

--- a/docs/user-api/eco-fleet-api/resources/trackers/resampling.md
+++ b/docs/user-api/eco-fleet-api/resources/trackers/resampling.md
@@ -14,7 +14,7 @@ Effective data management relies on **accurate and synchronized raw data**. Howe
 
 To tackle the challenges posed by incomplete or inconsistent data, we utilize advanced statistical models. With our API requests, you can easily **access and download processed datasets** from our platform for specific time periods. This API request specifically provides fuel-related data in a convenient CSV format.
 
-!!! note "**Data resampling** refers to the joint process of creating a uniform data structure by organizing existing values and generating new ones (for missing values) in a chronological order, while considering equal time intervals. This approach ensures data integrity and facilitates analysis."
+> **Data resampling** refers to the joint process of creating a uniform data structure by organizing existing values and generating new ones (for missing values) in a chronological order, while considering equal time intervals. This approach ensures data integrity and facilitates analysis.
 
 ## data_resampling
 ### Description
@@ -58,7 +58,7 @@ Additional list of resampling parameters
 * AVERAGE_IN_WINDOW- In this algorithm, the presence of delta is imperative. The median of all the neighboring values in the series within the interval [T-Δ, T+Δ], fixed_value if no values.
 * AVERAGE - To replace missing values in a series, we use the average of the two neighboring values. For any missing values between valid ones, we replace them with the average of the surrounding valid values. If the series begins or ends with missing values, we substitute them with the next or previous valid value accordingly. If delta is not equal to null than algorithm changes: if the interval [T-Δ, T+Δ] contains at least one value, otherwise fixed_value.
 
-!!! note "We recommend utilizing distinct methods for varying data types, as outlined in the table below. However, the choice of which methods to employ ultimately depends on your individual needs and expectations."
+> We recommend utilizing distinct methods for varying data types, as outlined in the table below. However, the choice of which methods to employ ultimately depends on your individual needs and expectations.
 
 | Method     | Data type            | Use case                                                                               |
 |:-----------|:---------------------|:---------------------------------------------------------------------------------------|

--- a/docs/user-api/frontend/extensions/delivery-app.md
+++ b/docs/user-api/frontend/extensions/delivery-app.md
@@ -1,17 +1,19 @@
 ---
 title: Application 'Courier on the map'
 description: Delivery is a special plugin which can be embedded to any other application or website and allows track user's task by external ID and bounded tracker in the real time.
+internal: true
 ---
 
 # App: Courier on the map
 
 **Delivery** is a special plugin which can be embedded to any other application or website and
- allows track user's task by external ID and bounded tracker in the real time.
+allows track user's task by external ID and bounded tracker in the real time.
 
+\##Usage
 
-##Usage
-
-    https://saas.navixy.com/pro/applications/delivery/?key=GENERATED_KEY
+```
+https://saas.navixy.com/pro/applications/delivery/?key=GENERATED_KEY
+```
 
 where key – is a session key generated with API call `/user/session/delivery/create`.
 
@@ -19,19 +21,19 @@ where key – is a session key generated with API call `/user/session/delivery/c
 
 The plugin can be easily customized with the following parameters provided as GET params:
 
-*   `performer\_type` – You can use an employee or vehicle label as the tracker marker label. 
-    Values: `employee`, `vehicle`, `tracker`.
-*   `performer\_label` – You can set the custom tracker marker label.
-*   `external\_id` – The task external ID, specified in task creation/edit form.
-*   `hide\_task`(1,0) – Hides task. In this mode you can track only the tracker(courier).
-*   `display\_fields` – You can show only important information in the task info panel. 
-    Names of fields are listed through a comma. Fields: label, description, address, period.
-*   `prompt\_placeholder`– The task external ID prompt placeholder e.g "Order ID"
-* `panel\_align` – Specifies the task info panel align. Values: `tl` – Top-Left corner,
+- `performer\_type` – You can use an employee or vehicle label as the tracker marker label.
+  Values: `employee`, `vehicle`, `tracker`.
+- `performer\_label` – You can set the custom tracker marker label.
+- `external\_id` – The task external ID, specified in task creation/edit form.
+- `hide\_task`(1,0) – Hides task. In this mode you can track only the tracker(courier).
+- `display\_fields` – You can show only important information in the task info panel.
+  Names of fields are listed through a comma. Fields: label, description, address, period.
+- `prompt\_placeholder`– The task external ID prompt placeholder e.g "Order ID"
+- `panel\_align` – Specifies the task info panel align. Values: `tl` – Top-Left corner,
   `tr` – Top-Right corner, `bl` – Bottom-Left corner, `br` – Bottom-Right corner.
-* `panel\_scale` – Specifies the task info panel size. Values: `small`, `medium`, `big` –
+- `panel\_scale` – Specifies the task info panel size. Values: `small`, `medium`, `big` –
   `medium` is the default value.
-* `color` – Specifies the task marker and tracker marker color. Values: `FF0000` (red), `FF9900` (orange), `339966` (
+- `color` – Specifies the task marker and tracker marker color. Values: `FF0000` (red), `FF9900` (orange), `339966` (
   green), `3366FF` (blue). `FF9900` (orange) by default.
 
 Available colors: `000000, 993300, 333300, 003300, 003366, 000080, 
@@ -41,7 +43,6 @@ Available colors: `000000, 993300, 333300, 003300, 003366, 000080,
 993366, C0C0C0, FF99CC, FFCC99, FFFF99, CCFFCC, CCFFFF, 99CCFF, 
 CC99FF, FFFFFF`.
 
-
 ### Autoscaling
 
 Autoscaling means that the scale of the map, and the center of the area are automatically selected so that all displayed
@@ -49,43 +50,42 @@ objects are visible.
 
 `autoscale`:
 
-*   `0` – do not scale
-*   `1` – scale (by default)
-
+- `0` – do not scale
+- `1` – scale (by default)
 
 ### Map scale
 
-The zoom parameter allows specifying map scale by default. Parameter will be 
+The zoom parameter allows specifying map scale by default. Parameter will be
 ignored with switched on autoscaling.
 
 `map`:
 
-*   `roadmap` – Google
-*   `satellite` – Google satellite
-*   `osm` – Open Street map
-*   `doublegis` – 2Gis
-*   `osmmapnik` – OSM mapnik
-*   `wikimapia` – Wikimapia
-*   `mailru` – Mail.ru
-*   `yandexpublic` – Yandex Public map
-*   `cdcom` – Progorod
-
+- `roadmap` – Google
+- `satellite` – Google satellite
+- `osm` – Open Street map
+- `doublegis` – 2Gis
+- `osmmapnik` – OSM mapnik
+- `wikimapia` – Wikimapia
+- `mailru` – Mail.ru
+- `yandexpublic` – Yandex Public map
+- `cdcom` – Progorod
 
 ## API for keys
 
 ### Authorisation on API
 
-To use the calls described further you have to be authorized in system as it 
+To use the calls described further you have to be authorized in system as it
 is described according to the link: [API authorization][1]
 
 [1]: ../../backend-api/getting-started/introduction.md#authorization-and-access-levels
-
 
 ### Creating a key
 
 Use the following API call to create a new key
 
-    http://api.domain.com/user/session/delivery/create/?hash=USER\_HASH
+```
+http://api.domain.com/user/session/delivery/create/?hash=USER\_HASH
+```
 
 answer example if the key is successfully generated:
 
@@ -97,16 +97,17 @@ answer example if the key is successfully generated:
 ```
 
 !!! warning "Important"
-    Previous key (if you already have got one), will be replaced with the new one. 
-    All the links like http://ui.domain.com/pro/applications/locator/?key= <old key> 
-    will not work anymore.
-
+Previous key (if you already have got one), will be replaced with the new one.
+All the links like <http://ui.domain.com/pro/applications/locator/?key=> <old key>
+will not work anymore.
 
 ### Retrieving a key
 
 To acquire the key you have created earlier, please use the method
 
-    http://api.domain.com/user/session/delivery/read/?hash=USER_HASH
+```
+http://api.domain.com/user/session/delivery/read/?hash=USER_HASH
+```
 
 The reply will look like as follows:
 

--- a/docs/user-api/frontend/extensions/mobile-tracker.md
+++ b/docs/user-api/frontend/extensions/mobile-tracker.md
@@ -1,4 +1,7 @@
+---
+internal: true
+---
+
 Plugins are ready-to-use software extensions which can be embedded into 3-rd parties software or web-projects.
 
 If you have more questions please contact our [support team](../../../general/contacts.md).
-

--- a/docs/user-api/frontend/extensions/ui-plugins.md
+++ b/docs/user-api/frontend/extensions/ui-plugins.md
@@ -12,7 +12,7 @@ when you click on it.
 Some apps have been developed by our partners and are available in [Marketplace](https://marketplace.navixy.com/). 
 To add them, contact the developer of the application.
 
-!!! note "If your domain is using an HTTPS connection, the link to the application must also be HTTPS. Otherwise, you will encounter a mixed content error." 
+> If your domain is using an HTTPS connection, the link to the application must also be HTTPS. Otherwise, you will encounter a mixed content error.
 
 
 ## Authorization in the application
@@ -28,7 +28,7 @@ By default, the web server sends the following cookies when an external applicat
 * User session hash as `hash=a6aa75587e5c59c32d347da438505fc3`.
 * Locale as `locale=en`.
 
-!!! note "If you do not want the server to send cookies, inform technical support and this function will be disabled."
+> If you do not want the server to send cookies, inform technical support and this function will be disabled.
 
 ## How to add an application
 
@@ -45,7 +45,7 @@ Contact [Navixy technical support](../../../general/contacts.md) and specify the
 Our specialists will do everything necessary, and the application will be available in the user interface.
 The application can be installed for all users or for a specific one.
 
-!!! note "If the app will be installed to the specific user, please contact the support team every time you need to add this app to another user. If the app installed for whole panel - all new users will automatically get the app. Also, the app can be installed to whole panel instead of specific users."
+> If the app will be installed to the specific user, please contact the support team every time you need to add this app to another user. If the app installed for whole panel - all new users will automatically get the app. Also, the app can be installed to whole panel instead of specific users.
 
 
 ### Standalone version


### PR DESCRIPTION
Fixed Notes and Warning syntax across the documentation. Now they are displayed correctly in Stoplight.