### PR TITLE
Fix pre-existing broken internal links (Pass 1 & 2)

### DIFF
--- a/docs/general/api-tools/zapier.md
+++ b/docs/general/api-tools/zapier.md
@@ -46,7 +46,7 @@ Example use cases include:
     Choose "New Tracker Event" as the trigger. Connect your account by providing a User Session Key or an API key.\
     ![New account connect](../../.gitbook/assets/newAccountConnect.png)
 
-    Obtain a User Session Key from Navixy Admin Panel -> Users -> User -> Get session key. For API keys, refer to [authentication](../../user-api/backend-api/getting-started/authentication.md).
+    Obtain a User Session Key from Navixy Admin Panel -> Users -> User -> Get session key. For API keys, refer to [authentication](../../user-api/authentication.md).
 
     Select the correct server (US for accounts starting with 1000xxxx, otherwise EU).
 3. **Specify Trigger Details**

--- a/docs/panel-api/resources/dealer/README.md
+++ b/docs/panel-api/resources/dealer/README.md
@@ -132,7 +132,7 @@ https://api.eu.navixy.com/v2/panel/dealer/get_info?hash=fa7bf873fab9333144e17137
 * `logo` (string): Path or URL to dealer's logotype or null.
 * `paas_activation_date` (string): Date of activation pay.
 * `features` (array of strings): Set of allowed [dealer features](../../../user-api/backend-api/resources/commons/dealer.md#dealer-features).
-* `default_user_time_zone` (string): [Time zone ID](../timezone.md) for new users created via [user/upload](broken-reference). This zone will also be selected by default when creating a new user in the Navixy Admin Panel.
+* `default_user_time_zone` (string): [Time zone ID](../timezone.md) for new users created via [user/upload](../user/README.md#upload). This zone will also be selected by default when creating a new user in the Navixy Admin Panel.
 
 #### Errors
 

--- a/docs/panel-api/resources/dealer/settings/service.md
+++ b/docs/panel-api/resources/dealer/settings/service.md
@@ -96,7 +96,7 @@ Let's explore the Service Settings object using the following example:
 * `privacy_policy_link` - string. Nullable, privacy policy link (it may be empty).
 * `tos` - string. Nullable, terms of service text (it may be empty).
 * `no_register_commands` - boolean. Prevents sending commands to devices on activation if `true`.
-* `default_user_time_zone` - string. [Time zone ID](../../timezone.md) for new users created via [user/upload](broken-reference). This time zone is also selected by default when creating a new user in the Navixy Admin Panel.
+* `default_user_time_zone` - string. [Time zone ID](../../timezone.md) for new users created via [user/upload](../../user/README.md#upload). This time zone is also selected by default when creating a new user in the Navixy Admin Panel.
 
 ## API actions
 

--- a/docs/user-api/backend-api/resources/commons/user/applications/README.md
+++ b/docs/user-api/backend-api/resources/commons/user/applications/README.md
@@ -18,6 +18,8 @@ However, if you need to automate application management and integrate external t
 * Delete existing applications
 * Enable/Disable - control application availability
 
+For detailed reference see [User application resources](user).
+
 ## How to create a new application
 
 To create a new user application using the user/application/update API, send a POST request with the required parameters.

--- a/docs/user-api/backend-api/resources/commons/user/applications/README.md
+++ b/docs/user-api/backend-api/resources/commons/user/applications/README.md
@@ -18,8 +18,6 @@ However, if you need to automate application management and integrate external t
 * Delete existing applications
 * Enable/Disable - control application availability
 
-For detailed reference see [User application resources](/broken/pages/0581b45ef03198e50e462ac93e42a311efe2b379).
-
 ## How to create a new application
 
 To create a new user application using the user/application/update API, send a POST request with the required parameters.

--- a/docs/user-api/backend-api/resources/commons/user/applications/README.md
+++ b/docs/user-api/backend-api/resources/commons/user/applications/README.md
@@ -18,7 +18,7 @@ However, if you need to automate application management and integrate external t
 * Delete existing applications
 * Enable/Disable - control application availability
 
-For detailed reference see [User application resources](user).
+For detailed reference see [User application resources](/broken/pages/b6ca25c8a18d2ae05c9bead8e284912f74c9f1c8).
 
 ## How to create a new application
 

--- a/docs/user-api/backend-api/resources/fleet/vehicle/avatar.md
+++ b/docs/user-api/backend-api/resources/fleet/vehicle/avatar.md
@@ -66,7 +66,7 @@ e.g. `https://api.eu.navixy.com/v2/static/vehicle/avatars/abcdef123456789.png`.
 
 **required sub-user rights**: `vehicle_update`
 
-**avatar\_file\_name** returned in response and will be returned from [/vehicle/list](broken-reference).
+**avatar\_file\_name** returned in response and will be returned from [/vehicle/list](README.md#list).
 
 **MUST** be a POST multipart request (multipart/form-data),\
 with one of the parts being an image file upload (with the name "file").

--- a/docs/user-api/backend-api/resources/tracking/delivery.md
+++ b/docs/user-api/backend-api/resources/tracking/delivery.md
@@ -66,10 +66,10 @@ https://api.eu.navixy.com/v2/delivery/read?hash=a6aa75587e5c59c32d347da438505fc3
 ```
 
 * `user_id` - master ID of the user to which the task belongs to.
-* `task` - a task object, for more info see [/task](../../../introduction/resources/tracking/broken-reference/)\
+* `task` - a task object, for more info see [/task](../field-service/task/README.md)\
   object structure.
-* `tracker` - corresponding tracker object, for more info see[tracker/](../../../introduction/resources/tracking/broken-reference/) object structure.
-* `restrictions` - tariff restrictions object, for more info see[user/get\_tariff\_restrictions](../../../introduction/resources/tracking/broken-reference/).
+* `tracker` - corresponding tracker object, for more info see[tracker/](tracker/README.md) object structure.
+* `restrictions` - tariff restrictions object, for more info see[user/get\_tariff\_restrictions](../commons/user/index.md#get_tariff_restrictions).
 * `first_name` - string. The first name of employee assigned to the task, or null if missing.
 * `middle_name` - string. The middle name of employee assigned to the task, or null if missing.
 * `last_name` - string. The last name of employee assigned to the task, or null if missing.
@@ -188,16 +188,16 @@ https://api.eu.navixy.com/v2/delivery/list?hash=a6aa75587e5c59c32d347da438505fc3
 }
 ```
 
-* `task` - a task object, for more info see [/task](../../../introduction/resources/tracking/broken-reference/) object\
+* `task` - a task object, for more info see [/task](../field-service/task/README.md) object\
   structure.
-* `tracker` - corresponding tracker object, for more info see[tracker/](../../../introduction/resources/tracking/broken-reference/) object structure.
+* `tracker` - corresponding tracker object, for more info see[tracker/](tracker/README.md) object structure.
 * `first_name` - string. The first name of employee assigned to the task, or null if missing.
 * `middle_name` - string. The middle name of employee assigned to the task, or null if missing.
 * `last_name` - string. The last name of employee assigned to the task, or null if missing.
 * `vehicle_label` - string. A label of the vehicle assigned to the task, or null if missing.
 * `estimated_time` - int. Estimated time of arrival in seconds, or null if unavailable.
 * `user_id` - master ID of the user to which the task belongs to.
-* `restrictions` - tariff restrictions object, for more info see[user/get\_tariff\_restrictions](../../../introduction/resources/tracking/broken-reference/).
+* `restrictions` - tariff restrictions object, for more info see[user/get\_tariff\_restrictions](../commons/user/index.md#get_tariff_restrictions).
 
 #### Errors
 

--- a/docs/user-api/backend-api/resources/tracking/delivery.md
+++ b/docs/user-api/backend-api/resources/tracking/delivery.md
@@ -68,8 +68,8 @@ https://api.eu.navixy.com/v2/delivery/read?hash=a6aa75587e5c59c32d347da438505fc3
 * `user_id` - master ID of the user to which the task belongs to.
 * `task` - a task object, for more info see [/task](../field-service/task/README.md)\
   object structure.
-* `tracker` - corresponding tracker object, for more info see[tracker/](tracker/README.md) object structure.
-* `restrictions` - tariff restrictions object, for more info see[user/get\_tariff\_restrictions](../commons/user/index.md#get_tariff_restrictions).
+* `tracker` - corresponding tracker object, for more info see [tracker/](tracker/README.md) object structure.
+* `restrictions` - tariff restrictions object, for more info see [user/get\_tariff\_restrictions](../commons/user/index.md#get_tariff_restrictions).
 * `first_name` - string. The first name of employee assigned to the task, or null if missing.
 * `middle_name` - string. The middle name of employee assigned to the task, or null if missing.
 * `last_name` - string. The last name of employee assigned to the task, or null if missing.
@@ -190,14 +190,14 @@ https://api.eu.navixy.com/v2/delivery/list?hash=a6aa75587e5c59c32d347da438505fc3
 
 * `task` - a task object, for more info see [/task](../field-service/task/README.md) object\
   structure.
-* `tracker` - corresponding tracker object, for more info see[tracker/](tracker/README.md) object structure.
+* `tracker` - corresponding tracker object, for more info see [tracker/](tracker/README.md) object structure.
 * `first_name` - string. The first name of employee assigned to the task, or null if missing.
 * `middle_name` - string. The middle name of employee assigned to the task, or null if missing.
 * `last_name` - string. The last name of employee assigned to the task, or null if missing.
 * `vehicle_label` - string. A label of the vehicle assigned to the task, or null if missing.
 * `estimated_time` - int. Estimated time of arrival in seconds, or null if unavailable.
 * `user_id` - master ID of the user to which the task belongs to.
-* `restrictions` - tariff restrictions object, for more info see[user/get\_tariff\_restrictions](../commons/user/index.md#get_tariff_restrictions).
+* `restrictions` - tariff restrictions object, for more info see [user/get\_tariff\_restrictions](../commons/user/index.md#get_tariff_restrictions).
 
 #### Errors
 

--- a/docs/user-api/backend-api/resources/tracking/track/index.md
+++ b/docs/user-api/backend-api/resources/tracking/track/index.md
@@ -213,7 +213,7 @@ where `track_info` is either `regular`, `single_report`, `merged` or `cluster`:
 * `avg_speed` - int. Average speed in km/h.
 * `event_count` - int. Number of events recorded during this track. This field will not be present if "count\_events" is set to `false`.
 * `norm_fuel_consumed` - float. Amount of fuel consumed during the track, measured in litres.\
-  This field will not be present if there's no [vehicle\_object](broken-reference) linked to the tracker or\
+  This field will not be present if there's no [vehicle\_object](../../fleet/vehicle/README.md#vehicle-object) linked to the tracker or\
   if "normAvgFuelConsumption" is not defined for the linked vehicle object.
 * `type` - [enum](../../../#data-types): `regular`, `single_report`, `merged`, `cluster`. Track type.
 * `gsm_lbs` - optional boolean. GSM LBS point flag.
@@ -287,7 +287,7 @@ where `track_info` is either `regular`, `single_report`, `merged` or `cluster`:
 * `avg_speed` - int. Average speed in km/h.
 * `event_count` - int. Number of events recorded during period. This field will not be present if "count\_events" is set to `false`.
 * `norm_fuel_consumed` - float. Amount of fuel consumed during period, measured in litres.\
-  This field will not be present if there's no [vehicle\_object](broken-reference) linked to the tracker or\
+  This field will not be present if there's no [vehicle\_object](../../fleet/vehicle/README.md#vehicle-object) linked to the tracker or\
   if "normAvgFuelConsumption" is not defined for the linked vehicle object.
 * `type` - [enum](../../../#data-types): `regular`, `single_report`, `merged`, `cluster`. Track type.
 * `gsm_lbs` - optional boolean. GSM LBS point flag.

--- a/docs/user-api/backend-api/resources/tracking/tracker/mobile.md
+++ b/docs/user-api/backend-api/resources/tracking/tracker/mobile.md
@@ -44,7 +44,7 @@ Common parameters are:
 }
 ```
 
-For `tracker` object structure, see [tracker/](../../../../introduction/resources/tracking/tracker/broken-reference/).
+For `tracker` object structure, see [tracker/](README.md).
 
 #### Errors
 

--- a/docs/user-api/frontend/extensions/ui-plugins.md
+++ b/docs/user-api/frontend/extensions/ui-plugins.md
@@ -56,4 +56,4 @@ You can find the instruction on installation of the software [here](https://docs
 You can also embed practically any custom application to the platform on your own. The User applications feature offers an unprecedented freedom when you need to display 3rd-party content without switching interfaces using UI or API. To learn more about this functionality, see:
 
 * [User documentation](https://docs.navixy.com/user-guide/user-applications) - detailed feature description and instruction on how to use it from the platform's UI.
-* [API documentation](user-applications.md) - instructions on how to use it through API requests.
+* [API documentation](../../backend-api/resources/commons/user/applications/README.md) - instructions on how to use it through API requests.


### PR DESCRIPTION
## Summary

- Fixes 1 GitBook placeholder link and 12 `broken-reference` occurrences across 8 files (Pass 1 & 2 findings)
- Corrects stale relative path to `authentication.md` in `zapier.md`
- Fixes missing spaces before links in `delivery.md` (pre-existing formatting issue)
- Corrects `ui-plugins.md` link to non-existent `user-applications.md`

## Changes

| File | Fix |
|---|---|
| `general/api-tools/zapier.md` | Correct path to `authentication.md` (removed non-existent `getting-started/` segment) |
| `user/.../user/applications/README.md` | Restore link to OpenAPI-generated page (GitBook internal ID from manual fix) |
| `panel-api/.../dealer/settings/service.md` | `broken-reference` → `../../user/README.md#upload` |
| `panel-api/.../dealer/README.md` | `broken-reference` → `../user/README.md#upload` |
| `fleet/vehicle/avatar.md` | `broken-reference` → `README.md#list` |
| `tracking/delivery.md` | 6 `broken-reference` links → task, tracker/, tariff_restrictions (×2 each); fix missing spaces |
| `tracking/track/index.md` | 2× `broken-reference` → `../../fleet/vehicle/README.md#vehicle-object` |
| `tracking/tracker/mobile.md` | `broken-reference` → `README.md` |
| `user-api/frontend/extensions/ui-plugins.md` | Replace non-existent `user-applications.md` with correct path to applications README |

## Test plan

- [x] Pass 1 & 2 link checker: 0 missing relative targets, 1 expected GitBook internal ID (OpenAPI page — works in GitBook)
- [x] Rebased cleanly on top of master (post output-control → commands rename)

🤖 Generated with [Claude Code](https://claude.com/claude-code)